### PR TITLE
feat: auto-fetch latest OSTK core patch version in docker image

### DIFF
--- a/docker/development/Dockerfile
+++ b/docker/development/Dockerfile
@@ -8,6 +8,11 @@ LABEL maintainer="lucas@loftorbital.com"
 
 # Dependencies
 
+# jq
+RUN apt-get update \
+ && apt-get install -y jq \
+ && rm -rf /var/lib/apt/lists/*
+
 ## {fmt}
 
 ARG FMT_VERSION="5.2.0"
@@ -48,12 +53,17 @@ RUN git clone --branch ${GEOMETRIC_TOOLS_ENGINE_VERSION} --depth 1 https://githu
 
 ## Open Space Toolkit ▸ Core
 
-ARG OSTK_CORE_VERSION="0.7.2"
+ARG OSTK_CORE_MAJOR="0"
+ARG OSTK_CORE_MINOR="7"
+
+## Force an image rebuild when new Core patch versions are detected
+ADD https://api.github.com/repos/open-space-collective/open-space-toolkit-core/git/matching-refs/tags/${OSTK_CORE_MAJOR}.${OSTK_CORE_MINOR} /tmp/open-space-toolkit-core/versions.json
 
 RUN mkdir -p /tmp/open-space-toolkit-core \
  && cd /tmp/open-space-toolkit-core \
- && wget --quiet https://github.com/open-space-collective/open-space-toolkit-core/releases/download/${OSTK_CORE_VERSION}/open-space-toolkit-core-${OSTK_CORE_VERSION}-1.x86_64-runtime.deb \
- && wget --quiet https://github.com/open-space-collective/open-space-toolkit-core/releases/download/${OSTK_CORE_VERSION}/open-space-toolkit-core-${OSTK_CORE_VERSION}-1.x86_64-devel.deb \
+ && export LATEST_PATCH_VERSION=$(jq -r .[-1].ref versions.json | cut -d "/" -f3) \
+ && wget --quiet https://github.com/open-space-collective/open-space-toolkit-core/releases/download/${LATEST_PATCH_VERSION}/open-space-toolkit-core-${LATEST_PATCH_VERSION}-1.x86_64-runtime.deb \
+ && wget --quiet https://github.com/open-space-collective/open-space-toolkit-core/releases/download/${LATEST_PATCH_VERSION}/open-space-toolkit-core-${LATEST_PATCH_VERSION}-1.x86_64-devel.deb \
  && apt-get install -y ./*.deb \
  && rm -rf /tmp/open-space-toolkit-core
 

--- a/docker/development/Dockerfile
+++ b/docker/development/Dockerfile
@@ -61,9 +61,9 @@ ADD https://api.github.com/repos/open-space-collective/open-space-toolkit-core/g
 
 RUN mkdir -p /tmp/open-space-toolkit-core \
  && cd /tmp/open-space-toolkit-core \
- && export LATEST_PATCH_VERSION=$(jq -r .[-1].ref versions.json | cut -d "/" -f3) \
- && wget --quiet https://github.com/open-space-collective/open-space-toolkit-core/releases/download/${LATEST_PATCH_VERSION}/open-space-toolkit-core-${LATEST_PATCH_VERSION}-1.x86_64-runtime.deb \
- && wget --quiet https://github.com/open-space-collective/open-space-toolkit-core/releases/download/${LATEST_PATCH_VERSION}/open-space-toolkit-core-${LATEST_PATCH_VERSION}-1.x86_64-devel.deb \
+ && export LATEST_PATCH_OF_MINOR=$(jq -r .[-1].ref versions.json | cut -d "/" -f3) \
+ && wget --quiet https://github.com/open-space-collective/open-space-toolkit-core/releases/download/${LATEST_PATCH_OF_MINOR}/open-space-toolkit-core-${LATEST_PATCH_OF_MINOR}-1.x86_64-runtime.deb \
+ && wget --quiet https://github.com/open-space-collective/open-space-toolkit-core/releases/download/${LATEST_PATCH_OF_MINOR}/open-space-toolkit-core-${LATEST_PATCH_OF_MINOR}-1.x86_64-devel.deb \
  && apt-get install -y ./*.deb \
  && rm -rf /tmp/open-space-toolkit-core
 


### PR DESCRIPTION
ADDs a json file that comes from the Github refs/tags api. We can query to match a semver pattern. For example:
`https://api.github.com/repos/open-space-collective/open-space-toolkit-core/git/matching-refs/tags/0.7`
Returns all tags matching `0.7`. i.e., if we follow semver properly, all patch tags. This returns:
```
[
  {
    "ref": "refs/tags/0.7.0",
    "node_id": "MDM6UmVmMTM2ODM0NzAwOnJlZnMvdGFncy8wLjcuMA==",
    "url": "https://api.github.com/repos/open-space-collective/open-space-toolkit-core/git/refs/tags/0.7.0",
    "object": {
      "sha": "3b378692446add8d51251df34a954f23d0374623",
      "type": "commit",
      "url": "https://api.github.com/repos/open-space-collective/open-space-toolkit-core/git/commits/3b378692446add8d51251df34a954f23d0374623"
    }
  },
  {
    "ref": "refs/tags/0.7.1",
    "node_id": "MDM6UmVmMTM2ODM0NzAwOnJlZnMvdGFncy8wLjcuMQ==",
    "url": "https://api.github.com/repos/open-space-collective/open-space-toolkit-core/git/refs/tags/0.7.1",
    "object": {
      "sha": "58f780a9921162dc451c5d4edd0b149b2f9d5223",
      "type": "commit",
      "url": "https://api.github.com/repos/open-space-collective/open-space-toolkit-core/git/commits/58f780a9921162dc451c5d4edd0b149b2f9d5223"
    }
  },
  {
    "ref": "refs/tags/0.7.2",
    "node_id": "MDM6UmVmMTM2ODM0NzAwOnJlZnMvdGFncy8wLjcuMg==",
    "url": "https://api.github.com/repos/open-space-collective/open-space-toolkit-core/git/refs/tags/0.7.2",
    "object": {
      "sha": "c370cf41622e3f244c88649bbac0f69588ba65c1",
      "type": "commit",
      "url": "https://api.github.com/repos/open-space-collective/open-space-toolkit-core/git/commits/c370cf41622e3f244c88649bbac0f69588ba65c1"
    }
  }
]
```

We can then use `jq` to extract the `ref` field of the last element, which is always the latest version:
`jq -r .[-1].ref versions.json`

and cut away the `refs/tags/` part:
`cut -d "/" -f3`
