### PR TITLE
refactor: explicit namespacing for trf::rot -> transformations::rotations

### DIFF
--- a/bindings/python/src/OpenSpaceToolkitMathematicsPy/Geometry/3D/Objects/Composite.cpp
+++ b/bindings/python/src/OpenSpaceToolkitMathematicsPy/Geometry/3D/Objects/Composite.cpp
@@ -28,7 +28,7 @@ inline void OpenSpaceToolkitMathematicsPy_Geometry_3D_Objects_Composite(pybind11
     using ostk::math::geometry::d3::objects::Pyramid;
     using ostk::math::geometry::d3::objects::Composite;
     using ostk::math::geometry::d3::Intersection;
-    using ostk::math::geometry::d3::trf::rot::Quaternion;
+    using ostk::math::geometry::d3::transformations::rotations::Quaternion;
 
     class_<Composite, Object>(aModule, "Composite")
 

--- a/bindings/python/src/OpenSpaceToolkitMathematicsPy/Geometry/3D/Objects/Cuboid.cpp
+++ b/bindings/python/src/OpenSpaceToolkitMathematicsPy/Geometry/3D/Objects/Cuboid.cpp
@@ -21,7 +21,7 @@ inline void OpenSpaceToolkitMathematicsPy_Geometry_3D_Objects_Cuboid(pybind11::m
     using ostk::math::geometry::d3::objects::Cuboid;
     using ostk::math::geometry::d3::objects::Pyramid;
     using ostk::math::geometry::d3::Intersection;
-    using ostk::math::geometry::d3::trf::rot::Quaternion;
+    using ostk::math::geometry::d3::transformations::rotations::Quaternion;
 
     //     scope in_Cuboid = class_<Cuboid, Shared<Cuboid>, bases<Object>>("Cuboid", no_init)
     class_<Cuboid, Object>(aModule, "Cuboid")

--- a/bindings/python/src/OpenSpaceToolkitMathematicsPy/Geometry/3D/Objects/Ellipsoid.cpp
+++ b/bindings/python/src/OpenSpaceToolkitMathematicsPy/Geometry/3D/Objects/Ellipsoid.cpp
@@ -21,7 +21,7 @@ inline void OpenSpaceToolkitMathematicsPy_Geometry_3D_Objects_Ellipsoid(pybind11
     using ostk::math::geometry::d3::objects::Pyramid;
     using ostk::math::geometry::d3::objects::Cone;
     using ostk::math::geometry::d3::Intersection;
-    using ostk::math::geometry::d3::trf::rot::Quaternion;
+    using ostk::math::geometry::d3::transformations::rotations::Quaternion;
 
     class_<Ellipsoid, Object>(aModule, "Ellipsoid")
 

--- a/bindings/python/src/OpenSpaceToolkitMathematicsPy/Geometry/3D/Objects/Pyramid.cpp
+++ b/bindings/python/src/OpenSpaceToolkitMathematicsPy/Geometry/3D/Objects/Pyramid.cpp
@@ -23,7 +23,7 @@ inline void OpenSpaceToolkitMathematicsPy_Geometry_3D_Objects_Pyramid(pybind11::
     using ostk::math::geometry::d3::objects::Ellipsoid;
     using ostk::math::geometry::d3::objects::Pyramid;
     using ostk::math::geometry::d3::Intersection;
-    using ostk::math::geometry::d3::trf::rot::Quaternion;
+    using ostk::math::geometry::d3::transformations::rotations::Quaternion;
 
     class_<Pyramid, Object>(aModule, "Pyramid")
 

--- a/bindings/python/src/OpenSpaceToolkitMathematicsPy/Geometry/3D/Transformation.cpp
+++ b/bindings/python/src/OpenSpaceToolkitMathematicsPy/Geometry/3D/Transformation.cpp
@@ -10,8 +10,8 @@ inline void OpenSpaceToolkitMathematicsPy_Geometry_3D_Transformation(pybind11::m
     using ostk::math::object::Matrix4d;
     using ostk::math::geometry::d3::objects::Point;
     using ostk::math::geometry::d3::Transformation;
-    using ostk::math::geometry::d3::trf::rot::RotationVector;
-    using ostk::math::geometry::d3::trf::rot::RotationMatrix;
+    using ostk::math::geometry::d3::transformations::rotations::RotationVector;
+    using ostk::math::geometry::d3::transformations::rotations::RotationMatrix;
 
     class_<Transformation> transformation(aModule, "Transformation");
 

--- a/bindings/python/src/OpenSpaceToolkitMathematicsPy/Geometry/3D/Transformations/Rotations/Quaternion.cpp
+++ b/bindings/python/src/OpenSpaceToolkitMathematicsPy/Geometry/3D/Transformations/Rotations/Quaternion.cpp
@@ -5,7 +5,7 @@
 #include <OpenSpaceToolkit/Mathematics/Geometry/3D/Transformations/Rotations/RotationVector.hpp>
 
 using ostk::core::ctnr::Array;
-using ostk::math::geometry::d3::trf::rot::Quaternion;
+using ostk::math::geometry::d3::transformations::rotations::Quaternion;
 
 void set_quaternion_array(const Array<Quaternion>& anArray)
 {
@@ -21,7 +21,7 @@ inline void OpenSpaceToolkitMathematicsPy_Geometry_3D_Transformations_Rotations_
 
     using ostk::math::object::Vector3d;
     using ostk::math::object::Vector4d;
-    using ostk::math::geometry::d3::trf::rot::Quaternion;
+    using ostk::math::geometry::d3::transformations::rotations::Quaternion;
 
     class_<Quaternion> quaternion(aModule, "Quaternion");
 

--- a/bindings/python/src/OpenSpaceToolkitMathematicsPy/Geometry/3D/Transformations/Rotations/RotationMatrix.cpp
+++ b/bindings/python/src/OpenSpaceToolkitMathematicsPy/Geometry/3D/Transformations/Rotations/RotationMatrix.cpp
@@ -14,7 +14,7 @@ inline void OpenSpaceToolkitMathematicsPy_Geometry_3D_Transformations_Rotations_
 
     using ostk::math::object::Vector3d;
     using ostk::math::object::Matrix3d;
-    using ostk::math::geometry::d3::trf::rot::RotationMatrix;
+    using ostk::math::geometry::d3::transformations::rotations::RotationMatrix;
 
     class_<RotationMatrix>(aModule, "RotationMatrix")
 

--- a/bindings/python/src/OpenSpaceToolkitMathematicsPy/Geometry/3D/Transformations/Rotations/RotationVector.cpp
+++ b/bindings/python/src/OpenSpaceToolkitMathematicsPy/Geometry/3D/Transformations/Rotations/RotationVector.cpp
@@ -15,7 +15,7 @@ inline void OpenSpaceToolkitMathematicsPy_Geometry_3D_Transformations_Rotations_
 
     using ostk::math::object::Vector3d;
     using ostk::math::geometry::Angle;
-    using ostk::math::geometry::d3::trf::rot::RotationVector;
+    using ostk::math::geometry::d3::transformations::rotations::RotationVector;
 
     class_<RotationVector>(aModule, "RotationVector")
 

--- a/bindings/python/test/geometry/d2/test_transformation.py
+++ b/bindings/python/test/geometry/d2/test_transformation.py
@@ -44,7 +44,7 @@ def test_geometry_d2_transformation_type():
 def test_geometry_d2_transformation_constructor():
     # Construction using python matrix
     M = [[1.0, 0.0, 0.0], [0.0, 1.0, 0.0], [0.0, 0.0, 1.0]]
-    transformation: Transformation = Transformation(M)
+    transformations: Transformation = Transformation(M)
 
     assert transformation is not None
     assert isinstance(transformation, Transformation)
@@ -52,7 +52,7 @@ def test_geometry_d2_transformation_constructor():
 
     # Construction using python numpy array
     M = np.array(M)
-    transformation: Transformation = Transformation(M)
+    transformations: Transformation = Transformation(M)
 
     assert transformation is not None
     assert isinstance(transformation, Transformation)
@@ -62,11 +62,11 @@ def test_geometry_d2_transformation_constructor():
 def test_geometry_d2_transformation_comparators():
     M1 = [[1.0, 0.0, 0.0], [0.0, 1.0, 0.0], [0.0, 0.0, 1.0]]
 
-    transformation: Transformation = Transformation(M1)
+    transformations: Transformation = Transformation(M1)
 
 
 def test_geometry_d2_transformation_defined():
-    transformation: Transformation = Transformation.undefined()
+    transformations: Transformation = Transformation.undefined()
 
     assert transformation is not None
     assert isinstance(transformation, Transformation)

--- a/bindings/python/test/geometry/d2/test_transformation.py
+++ b/bindings/python/test/geometry/d2/test_transformation.py
@@ -44,7 +44,7 @@ def test_geometry_d2_transformation_type():
 def test_geometry_d2_transformation_constructor():
     # Construction using python matrix
     M = [[1.0, 0.0, 0.0], [0.0, 1.0, 0.0], [0.0, 0.0, 1.0]]
-    transformations: Transformation = Transformation(M)
+    transformation: Transformation = Transformation(M)
 
     assert transformation is not None
     assert isinstance(transformation, Transformation)
@@ -52,7 +52,7 @@ def test_geometry_d2_transformation_constructor():
 
     # Construction using python numpy array
     M = np.array(M)
-    transformations: Transformation = Transformation(M)
+    transformation: Transformation = Transformation(M)
 
     assert transformation is not None
     assert isinstance(transformation, Transformation)
@@ -62,11 +62,11 @@ def test_geometry_d2_transformation_constructor():
 def test_geometry_d2_transformation_comparators():
     M1 = [[1.0, 0.0, 0.0], [0.0, 1.0, 0.0], [0.0, 0.0, 1.0]]
 
-    transformations: Transformation = Transformation(M1)
+    transformation: Transformation = Transformation(M1)
 
 
 def test_geometry_d2_transformation_defined():
-    transformations: Transformation = Transformation.undefined()
+    transformation: Transformation = Transformation.undefined()
 
     assert transformation is not None
     assert isinstance(transformation, Transformation)

--- a/include/OpenSpaceToolkit/Mathematics/Geometry/3D/Objects/Ellipsoid.hpp
+++ b/include/OpenSpaceToolkit/Mathematics/Geometry/3D/Objects/Ellipsoid.hpp
@@ -26,7 +26,7 @@ using ostk::math::object::Matrix3d;
 using ostk::math::geometry::d3::Object;
 using ostk::math::geometry::d3::objects::Point;
 using ostk::math::geometry::d3::Intersection;
-using ostk::math::geometry::d3::trf::rot::Quaternion;
+using ostk::math::geometry::d3::transformations::rotations::Quaternion;
 
 #define DEFAULT_ORIENTATION Quaternion::Unit()
 

--- a/include/OpenSpaceToolkit/Mathematics/Geometry/3D/Transformation.hpp
+++ b/include/OpenSpaceToolkit/Mathematics/Geometry/3D/Transformation.hpp
@@ -32,8 +32,8 @@ using ostk::math::object::Matrix4d;
 using ostk::math::geometry::Angle;
 using ostk::math::geometry::d3::Object;
 using ostk::math::geometry::d3::objects::Point;
-using ostk::math::geometry::d3::trf::rot::RotationVector;
-using ostk::math::geometry::d3::trf::rot::RotationMatrix;
+using ostk::math::geometry::d3::transformations::rotations::RotationVector;
+using ostk::math::geometry::d3::transformations::rotations::RotationMatrix;
 
 class Transformation
 {

--- a/include/OpenSpaceToolkit/Mathematics/Geometry/3D/Transformations/Rotations/EulerAngle.hpp
+++ b/include/OpenSpaceToolkit/Mathematics/Geometry/3D/Transformations/Rotations/EulerAngle.hpp
@@ -11,13 +11,13 @@ namespace geometry
 {
 namespace d3
 {
-namespace transformation
+namespace transformations
 {
-namespace rotation
+namespace rotations
 {
 
 }
-}  // namespace transformation
+}  // namespace transformations
 }  // namespace d3
 }  // namespace geometry
 }  // namespace math

--- a/include/OpenSpaceToolkit/Mathematics/Geometry/3D/Transformations/Rotations/EulerAngle.hpp
+++ b/include/OpenSpaceToolkit/Mathematics/Geometry/3D/Transformations/Rotations/EulerAngle.hpp
@@ -11,13 +11,13 @@ namespace geometry
 {
 namespace d3
 {
-namespace trf
+namespace transformation
 {
-namespace rot
+namespace rotation
 {
 
 }
-}  // namespace trf
+}  // namespace transformation
 }  // namespace d3
 }  // namespace geometry
 }  // namespace math

--- a/include/OpenSpaceToolkit/Mathematics/Geometry/3D/Transformations/Rotations/Quaternion.hpp
+++ b/include/OpenSpaceToolkit/Mathematics/Geometry/3D/Transformations/Rotations/Quaternion.hpp
@@ -18,9 +18,9 @@ namespace geometry
 {
 namespace d3
 {
-namespace transformation
+namespace transformations
 {
-namespace rotation
+namespace rotations
 {
 
 using ostk::core::types::Integer;
@@ -616,7 +616,7 @@ class Quaternion
     /// @param              [in] aRotationVector A rotation vector
     /// @return             Quaternion
 
-    static Quaternion RotationVector(const rot::RotationVector& aRotationVector);
+    static Quaternion RotationVector(const rotations::RotationVector& aRotationVector);
 
     /// @brief              Constructs a rquaternion from a rotation matrix
     ///
@@ -627,7 +627,7 @@ class Quaternion
     /// @param              [in] aRotationMatrix A rotation matrix
     /// @return             Quaternion
 
-    static Quaternion RotationMatrix(const rot::RotationMatrix& aRotationMatrix);
+    static Quaternion RotationMatrix(const rotations::RotationMatrix& aRotationMatrix);
 
     /// @brief              Constructs a quaternion from a string
     ///
@@ -713,8 +713,8 @@ class Quaternion
     Real s_;
 };
 
-}  // namespace rotation
-}  // namespace transformation
+}  // namespace rotations
+}  // namespace transformations
 }  // namespace d3
 }  // namespace geometry
 }  // namespace math

--- a/include/OpenSpaceToolkit/Mathematics/Geometry/3D/Transformations/Rotations/Quaternion.hpp
+++ b/include/OpenSpaceToolkit/Mathematics/Geometry/3D/Transformations/Rotations/Quaternion.hpp
@@ -18,9 +18,9 @@ namespace geometry
 {
 namespace d3
 {
-namespace trf
+namespace transformation
 {
-namespace rot
+namespace rotation
 {
 
 using ostk::core::types::Integer;
@@ -713,8 +713,8 @@ class Quaternion
     Real s_;
 };
 
-}  // namespace rot
-}  // namespace trf
+}  // namespace rotation
+}  // namespace transformation
 }  // namespace d3
 }  // namespace geometry
 }  // namespace math

--- a/include/OpenSpaceToolkit/Mathematics/Geometry/3D/Transformations/Rotations/RotationMatrix.hpp
+++ b/include/OpenSpaceToolkit/Mathematics/Geometry/3D/Transformations/Rotations/RotationMatrix.hpp
@@ -18,9 +18,9 @@ namespace geometry
 {
 namespace d3
 {
-namespace transformation
+namespace transformations
 {
-namespace rotation
+namespace rotations
 {
 
 using ostk::core::types::Index;
@@ -302,7 +302,7 @@ class RotationMatrix
     /// @param              [in] aQuaternion A quaternion
     /// @return             Rotation matrix
 
-    static RotationMatrix Quaternion(const rot::Quaternion& aQuaternion);
+    static RotationMatrix Quaternion(const rotations::Quaternion& aQuaternion);
 
     /// @brief              Constructs a rotation matrix from a rotation vector
     ///
@@ -314,7 +314,7 @@ class RotationMatrix
     /// @param              [in] aRotationVector A rotation vector
     /// @return             Rotation matrix
 
-    static RotationMatrix RotationVector(const rot::RotationVector& aRotationVector);
+    static RotationMatrix RotationVector(const rotations::RotationVector& aRotationVector);
 
    private:
     Matrix3d matrix_;
@@ -322,8 +322,8 @@ class RotationMatrix
     RotationMatrix();
 };
 
-}  // namespace rotation
-}  // namespace transformation
+}  // namespace rotations
+}  // namespace transformations
 }  // namespace d3
 }  // namespace geometry
 }  // namespace math

--- a/include/OpenSpaceToolkit/Mathematics/Geometry/3D/Transformations/Rotations/RotationMatrix.hpp
+++ b/include/OpenSpaceToolkit/Mathematics/Geometry/3D/Transformations/Rotations/RotationMatrix.hpp
@@ -18,9 +18,9 @@ namespace geometry
 {
 namespace d3
 {
-namespace trf
+namespace transformation
 {
-namespace rot
+namespace rotation
 {
 
 using ostk::core::types::Index;
@@ -322,8 +322,8 @@ class RotationMatrix
     RotationMatrix();
 };
 
-}  // namespace rot
-}  // namespace trf
+}  // namespace rotation
+}  // namespace transformation
 }  // namespace d3
 }  // namespace geometry
 }  // namespace math

--- a/include/OpenSpaceToolkit/Mathematics/Geometry/3D/Transformations/Rotations/RotationVector.hpp
+++ b/include/OpenSpaceToolkit/Mathematics/Geometry/3D/Transformations/Rotations/RotationVector.hpp
@@ -17,9 +17,9 @@ namespace geometry
 {
 namespace d3
 {
-namespace trf
+namespace transformation
 {
-namespace rot
+namespace rotation
 {
 
 using ostk::core::types::Real;
@@ -198,8 +198,8 @@ class RotationVector
     RotationVector();
 };
 
-}  // namespace rot
-}  // namespace trf
+}  // namespace rotation
+}  // namespace transformation
 }  // namespace d3
 }  // namespace geometry
 }  // namespace math

--- a/include/OpenSpaceToolkit/Mathematics/Geometry/3D/Transformations/Rotations/RotationVector.hpp
+++ b/include/OpenSpaceToolkit/Mathematics/Geometry/3D/Transformations/Rotations/RotationVector.hpp
@@ -17,9 +17,9 @@ namespace geometry
 {
 namespace d3
 {
-namespace transformation
+namespace transformations
 {
-namespace rotation
+namespace rotations
 {
 
 using ostk::core::types::Real;
@@ -178,7 +178,7 @@ class RotationVector
     /// @param              [in] aQuaternion A quaternion
     /// @return             Rotation vector
 
-    static RotationVector Quaternion(const rot::Quaternion& aQuaternion);
+    static RotationVector Quaternion(const rotations::Quaternion& aQuaternion);
 
     /// @brief              Constructs a rotation vector from a rotation matrix
     ///
@@ -189,7 +189,7 @@ class RotationVector
     /// @param              [in] aRotationMatrix A rotation matrix
     /// @return             Rotation vector
 
-    static RotationVector RotationMatrix(const rot::RotationMatrix& aRotationMatrix);
+    static RotationVector RotationMatrix(const rotations::RotationMatrix& aRotationMatrix);
 
    private:
     Vector3d axis_;
@@ -198,8 +198,8 @@ class RotationVector
     RotationVector();
 };
 
-}  // namespace rotation
-}  // namespace transformation
+}  // namespace rotations
+}  // namespace transformations
 }  // namespace d3
 }  // namespace geometry
 }  // namespace math

--- a/src/OpenSpaceToolkit/Mathematics/Geometry/3D/Objects/Composite.cpp
+++ b/src/OpenSpaceToolkit/Mathematics/Geometry/3D/Objects/Composite.cpp
@@ -434,7 +434,7 @@ void Composite::print(std::ostream& anOutputStream, bool displayDecorators) cons
 
 void Composite::applyTransformation(const Transformation& aTransformation)
 {
-    using ostk::math::geometry::d3::trf::rot::RotationMatrix;
+    using ostk::math::geometry::d3::transformations::rotations::RotationMatrix;
 
     if (!aTransformation.isDefined())
     {

--- a/src/OpenSpaceToolkit/Mathematics/Geometry/3D/Objects/Cone.cpp
+++ b/src/OpenSpaceToolkit/Mathematics/Geometry/3D/Objects/Cone.cpp
@@ -242,8 +242,8 @@ Angle Cone::getAngle() const
 Array<Ray> Cone::getRaysOfLateralSurface(const Size aRayCount) const
 {
     using ostk::math::object::Interval;
-    using ostk::math::geometry::d3::trf::rot::Quaternion;
-    using ostk::math::geometry::d3::trf::rot::RotationVector;
+    using ostk::math::geometry::d3::transformations::rotations::Quaternion;
+    using ostk::math::geometry::d3::transformations::rotations::RotationVector;
 
     if (aRayCount == 0)
     {

--- a/src/OpenSpaceToolkit/Mathematics/Geometry/3D/Objects/Cuboid.cpp
+++ b/src/OpenSpaceToolkit/Mathematics/Geometry/3D/Objects/Cuboid.cpp
@@ -452,7 +452,7 @@ void Cuboid::print(std::ostream& anOutputStream, bool displayDecorators) const
 
 void Cuboid::applyTransformation(const Transformation& aTransformation)
 {
-    using ostk::math::geometry::d3::trf::rot::RotationMatrix;
+    using ostk::math::geometry::d3::transformations::rotations::RotationMatrix;
 
     if (!aTransformation.isDefined())
     {

--- a/src/OpenSpaceToolkit/Mathematics/Geometry/3D/Objects/Ellipsoid.cpp
+++ b/src/OpenSpaceToolkit/Mathematics/Geometry/3D/Objects/Ellipsoid.cpp
@@ -914,7 +914,7 @@ void Ellipsoid::print(std::ostream& anOutputStream, bool displayDecorators) cons
 
 void Ellipsoid::applyTransformation(const Transformation& aTransformation)
 {
-    using ostk::math::geometry::d3::trf::rot::RotationMatrix;
+    using ostk::math::geometry::d3::transformations::rotations::RotationMatrix;
 
     if (!aTransformation.isDefined())
     {

--- a/src/OpenSpaceToolkit/Mathematics/Geometry/3D/Objects/Pyramid.cpp
+++ b/src/OpenSpaceToolkit/Mathematics/Geometry/3D/Objects/Pyramid.cpp
@@ -272,8 +272,8 @@ Polygon Pyramid::getLateralFaceAt(const Index aLateralFaceIndex) const
 Array<Ray> Pyramid::getRaysOfLateralFaceAt(const Index aLateralFaceIndex, const Size aRayCount) const
 {
     using ostk::math::object::Interval;
-    using ostk::math::geometry::d3::trf::rot::Quaternion;
-    using ostk::math::geometry::d3::trf::rot::RotationVector;
+    using ostk::math::geometry::d3::transformations::rotations::Quaternion;
+    using ostk::math::geometry::d3::transformations::rotations::RotationVector;
 
     // if (aRayCount < 2)
     // {

--- a/src/OpenSpaceToolkit/Mathematics/Geometry/3D/Transformations/Rotations/Quaternion.cpp
+++ b/src/OpenSpaceToolkit/Mathematics/Geometry/3D/Transformations/Rotations/Quaternion.cpp
@@ -15,9 +15,9 @@ namespace geometry
 {
 namespace d3
 {
-namespace transformation
+namespace transformations
 {
-namespace rotation
+namespace rotations
 {
 
 Quaternion::Quaternion(
@@ -496,7 +496,7 @@ Quaternion Quaternion::XYZS(
     return {aFirstComponent, aSecondComponent, aThirdComponent, aFourthComponent, Quaternion::Format::XYZS};
 }
 
-Quaternion Quaternion::RotationVector(const rot::RotationVector& aRotationVector)
+Quaternion Quaternion::RotationVector(const rotations::RotationVector& aRotationVector)
 {
     /// @ref Markley F. L.: Fundamentals of Spacecraft Attitude Determination and Control, 45
 
@@ -508,7 +508,7 @@ Quaternion Quaternion::RotationVector(const rot::RotationVector& aRotationVector
     return Quaternion(vectorPart, scalarPart).normalize();
 }
 
-Quaternion Quaternion::RotationMatrix(const rot::RotationMatrix& aRotationMatrix)
+Quaternion Quaternion::RotationMatrix(const rotations::RotationMatrix& aRotationMatrix)
 {
     /// @ref Markley F. L.: Fundamentals of Spacecraft Attitude Determination and Control, 48
     /// @note Should we use this method instead?
@@ -654,8 +654,8 @@ Quaternion Quaternion::SLERP(
     return (aFirstQuaternion * ((aFirstQuaternion.toInverse() * (-1.0) * aSecondQuaternion) ^ aRatio)).toNormalized();
 }
 
-}  // namespace rotation
-}  // namespace transformation
+}  // namespace rotations
+}  // namespace transformations
 }  // namespace d3
 }  // namespace geometry
 }  // namespace math

--- a/src/OpenSpaceToolkit/Mathematics/Geometry/3D/Transformations/Rotations/Quaternion.cpp
+++ b/src/OpenSpaceToolkit/Mathematics/Geometry/3D/Transformations/Rotations/Quaternion.cpp
@@ -15,9 +15,9 @@ namespace geometry
 {
 namespace d3
 {
-namespace trf
+namespace transformation
 {
-namespace rot
+namespace rotation
 {
 
 Quaternion::Quaternion(
@@ -654,8 +654,8 @@ Quaternion Quaternion::SLERP(
     return (aFirstQuaternion * ((aFirstQuaternion.toInverse() * (-1.0) * aSecondQuaternion) ^ aRatio)).toNormalized();
 }
 
-}  // namespace rot
-}  // namespace trf
+}  // namespace rotation
+}  // namespace transformation
 }  // namespace d3
 }  // namespace geometry
 }  // namespace math

--- a/src/OpenSpaceToolkit/Mathematics/Geometry/3D/Transformations/Rotations/RotationMatrix.cpp
+++ b/src/OpenSpaceToolkit/Mathematics/Geometry/3D/Transformations/Rotations/RotationMatrix.cpp
@@ -15,9 +15,9 @@ namespace geometry
 {
 namespace d3
 {
-namespace trf
+namespace transformation
 {
-namespace rot
+namespace rotation
 {
 
 RotationMatrix::RotationMatrix(const Matrix3d& aMatrix)
@@ -533,8 +533,8 @@ RotationMatrix::RotationMatrix()
 {
 }
 
-}  // namespace rot
-}  // namespace trf
+}  // namespace rotation
+}  // namespace transformation
 }  // namespace d3
 }  // namespace geometry
 }  // namespace math

--- a/src/OpenSpaceToolkit/Mathematics/Geometry/3D/Transformations/Rotations/RotationMatrix.cpp
+++ b/src/OpenSpaceToolkit/Mathematics/Geometry/3D/Transformations/Rotations/RotationMatrix.cpp
@@ -15,9 +15,9 @@ namespace geometry
 {
 namespace d3
 {
-namespace transformation
+namespace transformations
 {
-namespace rotation
+namespace rotations
 {
 
 RotationMatrix::RotationMatrix(const Matrix3d& aMatrix)
@@ -453,7 +453,7 @@ RotationMatrix RotationMatrix::Columns(
     return RotationMatrix(matrix);
 }
 
-RotationMatrix RotationMatrix::Quaternion(const rot::Quaternion& aQuaternion)
+RotationMatrix RotationMatrix::Quaternion(const rotations::Quaternion& aQuaternion)
 {
     if (!aQuaternion.isDefined())
     {
@@ -465,7 +465,7 @@ RotationMatrix RotationMatrix::Quaternion(const rot::Quaternion& aQuaternion)
         throw ostk::core::error::RuntimeError("Quaternion is not unitary.");
     }
 
-    if (aQuaternion == rot::Quaternion::Unit())
+    if (aQuaternion == rotations::Quaternion::Unit())
     {
         return RotationMatrix::Unit();
     }
@@ -494,7 +494,7 @@ RotationMatrix RotationMatrix::Quaternion(const rot::Quaternion& aQuaternion)
     return RotationMatrix(matrix);
 }
 
-RotationMatrix RotationMatrix::RotationVector(const rot::RotationVector& aRotationVector)
+RotationMatrix RotationMatrix::RotationVector(const rotations::RotationVector& aRotationVector)
 {
     if (!aRotationVector.isDefined())
     {
@@ -533,8 +533,8 @@ RotationMatrix::RotationMatrix()
 {
 }
 
-}  // namespace rotation
-}  // namespace transformation
+}  // namespace rotations
+}  // namespace transformations
 }  // namespace d3
 }  // namespace geometry
 }  // namespace math

--- a/src/OpenSpaceToolkit/Mathematics/Geometry/3D/Transformations/Rotations/RotationVector.cpp
+++ b/src/OpenSpaceToolkit/Mathematics/Geometry/3D/Transformations/Rotations/RotationVector.cpp
@@ -15,9 +15,9 @@ namespace geometry
 {
 namespace d3
 {
-namespace transformation
+namespace transformations
 {
-namespace rotation
+namespace rotations
 {
 
 RotationVector::RotationVector(const Vector3d& anAxis, const Angle& anAngle)
@@ -142,7 +142,7 @@ RotationVector RotationVector::Z(const Angle& anAngle)
     return {Vector3d::Z(), anAngle};
 }
 
-RotationVector RotationVector::Quaternion(const rot::Quaternion& aQuaternion)
+RotationVector RotationVector::Quaternion(const rotations::Quaternion& aQuaternion)
 {
     if (!aQuaternion.isDefined())
     {
@@ -165,7 +165,7 @@ RotationVector RotationVector::Quaternion(const rot::Quaternion& aQuaternion)
     return RotationVector(axis, angle);
 }
 
-RotationVector RotationVector::RotationMatrix(const rot::RotationMatrix& aRotationMatrix)
+RotationVector RotationVector::RotationMatrix(const rotations::RotationMatrix& aRotationMatrix)
 {
     if (!aRotationMatrix.isDefined())
     {
@@ -195,8 +195,8 @@ RotationVector::RotationVector()
 {
 }
 
-}  // namespace rotation
-}  // namespace transformation
+}  // namespace rotations
+}  // namespace transformations
 }  // namespace d3
 }  // namespace geometry
 }  // namespace math

--- a/src/OpenSpaceToolkit/Mathematics/Geometry/3D/Transformations/Rotations/RotationVector.cpp
+++ b/src/OpenSpaceToolkit/Mathematics/Geometry/3D/Transformations/Rotations/RotationVector.cpp
@@ -15,9 +15,9 @@ namespace geometry
 {
 namespace d3
 {
-namespace trf
+namespace transformation
 {
-namespace rot
+namespace rotation
 {
 
 RotationVector::RotationVector(const Vector3d& anAxis, const Angle& anAngle)
@@ -195,8 +195,8 @@ RotationVector::RotationVector()
 {
 }
 
-}  // namespace rot
-}  // namespace trf
+}  // namespace rotation
+}  // namespace transformation
 }  // namespace d3
 }  // namespace geometry
 }  // namespace math

--- a/test/OpenSpaceToolkit/Mathematics/Geometry/3D/Objects/Cone.test.cpp
+++ b/test/OpenSpaceToolkit/Mathematics/Geometry/3D/Objects/Cone.test.cpp
@@ -514,7 +514,7 @@ TEST(OpenSpaceToolkit_Mathematics_Geometry_3D_Objects_Cone, ApplyTransformation)
     using ostk::math::geometry::d3::objects::Point;
     using ostk::math::geometry::d3::objects::Cone;
     using ostk::math::geometry::d3::Transformation;
-    using ostk::math::geometry::d3::trf::rot::RotationVector;
+    using ostk::math::geometry::d3::transformations::rotations::RotationVector;
 
     // Translation
 

--- a/test/OpenSpaceToolkit/Mathematics/Geometry/3D/Objects/Cuboid.test.cpp
+++ b/test/OpenSpaceToolkit/Mathematics/Geometry/3D/Objects/Cuboid.test.cpp
@@ -1001,8 +1001,8 @@ TEST(OpenSpaceToolkit_Mathematics_Geometry_3D_Objects_Cuboid, ApplyTransformatio
     using ostk::math::geometry::d3::objects::Point;
     using ostk::math::geometry::d3::objects::Cuboid;
     using ostk::math::geometry::d3::Transformation;
-    using ostk::math::geometry::d3::trf::rot::Quaternion;
-    using ostk::math::geometry::d3::trf::rot::RotationVector;
+    using ostk::math::geometry::d3::transformations::rotations::Quaternion;
+    using ostk::math::geometry::d3::transformations::rotations::RotationVector;
 
     // Translation
 

--- a/test/OpenSpaceToolkit/Mathematics/Geometry/3D/Objects/Ellipsoid.test.cpp
+++ b/test/OpenSpaceToolkit/Mathematics/Geometry/3D/Objects/Ellipsoid.test.cpp
@@ -16,7 +16,7 @@
 
 TEST(OpenSpaceToolkit_Mathematics_Geometry_3D_Objects_Ellipsoid, Constructor)
 {
-    using ostk::math::geometry::d3::trf::rot::Quaternion;
+    using ostk::math::geometry::d3::transformations::rotations::Quaternion;
     using ostk::math::geometry::d3::objects::Ellipsoid;
 
     {
@@ -42,8 +42,8 @@ TEST(OpenSpaceToolkit_Mathematics_Geometry_3D_Objects_Ellipsoid, EqualToOperator
 {
     using ostk::math::geometry::Angle;
     using ostk::math::geometry::d3::objects::Ellipsoid;
-    using ostk::math::geometry::d3::trf::rot::Quaternion;
-    using ostk::math::geometry::d3::trf::rot::RotationVector;
+    using ostk::math::geometry::d3::transformations::rotations::Quaternion;
+    using ostk::math::geometry::d3::transformations::rotations::RotationVector;
 
     {
         ASSERT_TRUE(Ellipsoid({1.0, 2.0, 3.0}, 4.0, 5.0, 6.0) == Ellipsoid({1.0, 2.0, 3.0}, 4.0, 5.0, 6.0));
@@ -88,8 +88,8 @@ TEST(OpenSpaceToolkit_Mathematics_Geometry_3D_Objects_Ellipsoid, NotEqualToOpera
 {
     using ostk::math::geometry::Angle;
     using ostk::math::geometry::d3::objects::Ellipsoid;
-    using ostk::math::geometry::d3::trf::rot::Quaternion;
-    using ostk::math::geometry::d3::trf::rot::RotationVector;
+    using ostk::math::geometry::d3::transformations::rotations::Quaternion;
+    using ostk::math::geometry::d3::transformations::rotations::RotationVector;
 
     {
         ASSERT_TRUE(Ellipsoid({1.0, 2.0, 3.0}, 4.0, 5.0, 6.0) != Ellipsoid({1.0, 2.0, 4.0}, 4.0, 5.0, 6.0));
@@ -842,8 +842,8 @@ TEST(OpenSpaceToolkit_Mathematics_Geometry_3D_Objects_Ellipsoid, GetFirstAxis)
     using ostk::math::object::Vector3d;
     using ostk::math::geometry::Angle;
     using ostk::math::geometry::d3::objects::Ellipsoid;
-    using ostk::math::geometry::d3::trf::rot::Quaternion;
-    using ostk::math::geometry::d3::trf::rot::RotationVector;
+    using ostk::math::geometry::d3::transformations::rotations::Quaternion;
+    using ostk::math::geometry::d3::transformations::rotations::RotationVector;
 
     {
         ASSERT_EQ(Vector3d(1.0, 0.0, 0.0), Ellipsoid({1.0, 2.0, 3.0}, 4.0, 5.0, 6.0).getFirstAxis());
@@ -871,8 +871,8 @@ TEST(OpenSpaceToolkit_Mathematics_Geometry_3D_Objects_Ellipsoid, GetSecondAxis)
     using ostk::math::object::Vector3d;
     using ostk::math::geometry::Angle;
     using ostk::math::geometry::d3::objects::Ellipsoid;
-    using ostk::math::geometry::d3::trf::rot::Quaternion;
-    using ostk::math::geometry::d3::trf::rot::RotationVector;
+    using ostk::math::geometry::d3::transformations::rotations::Quaternion;
+    using ostk::math::geometry::d3::transformations::rotations::RotationVector;
 
     {
         ASSERT_EQ(Vector3d(0.0, 1.0, 0.0), Ellipsoid({1.0, 2.0, 3.0}, 4.0, 5.0, 6.0).getSecondAxis());
@@ -900,8 +900,8 @@ TEST(OpenSpaceToolkit_Mathematics_Geometry_3D_Objects_Ellipsoid, GetThirdAxis)
     using ostk::math::object::Vector3d;
     using ostk::math::geometry::Angle;
     using ostk::math::geometry::d3::objects::Ellipsoid;
-    using ostk::math::geometry::d3::trf::rot::Quaternion;
-    using ostk::math::geometry::d3::trf::rot::RotationVector;
+    using ostk::math::geometry::d3::transformations::rotations::Quaternion;
+    using ostk::math::geometry::d3::transformations::rotations::RotationVector;
 
     {
         ASSERT_EQ(Vector3d(0.0, 0.0, 1.0), Ellipsoid({1.0, 2.0, 3.0}, 4.0, 5.0, 6.0).getThirdAxis());
@@ -924,7 +924,7 @@ TEST(OpenSpaceToolkit_Mathematics_Geometry_3D_Objects_Ellipsoid, GetThirdAxis)
 
 TEST(OpenSpaceToolkit_Mathematics_Geometry_3D_Objects_Ellipsoid, GetOrientation)
 {
-    using ostk::math::geometry::d3::trf::rot::Quaternion;
+    using ostk::math::geometry::d3::transformations::rotations::Quaternion;
     using ostk::math::geometry::d3::objects::Ellipsoid;
 
     {
@@ -950,9 +950,9 @@ TEST(OpenSpaceToolkit_Mathematics_Geometry_3D_Objects_Ellipsoid, GetMatrix)
     using ostk::math::object::Matrix3d;
     using ostk::math::geometry::Angle;
     using ostk::math::geometry::d3::objects::Ellipsoid;
-    using ostk::math::geometry::d3::trf::rot::Quaternion;
-    using ostk::math::geometry::d3::trf::rot::RotationVector;
-    using ostk::math::geometry::d3::trf::rot::RotationMatrix;
+    using ostk::math::geometry::d3::transformations::rotations::Quaternion;
+    using ostk::math::geometry::d3::transformations::rotations::RotationVector;
+    using ostk::math::geometry::d3::transformations::rotations::RotationMatrix;
 
     {
         Matrix3d referenceEllipsoidMatrix;
@@ -1561,8 +1561,8 @@ TEST(OpenSpaceToolkit_Mathematics_Geometry_3D_Objects_Ellipsoid, ApplyTransforma
     using ostk::math::geometry::Angle;
     using ostk::math::geometry::d3::objects::Ellipsoid;
     using ostk::math::geometry::d3::Transformation;
-    using ostk::math::geometry::d3::trf::rot::Quaternion;
-    using ostk::math::geometry::d3::trf::rot::RotationVector;
+    using ostk::math::geometry::d3::transformations::rotations::Quaternion;
+    using ostk::math::geometry::d3::transformations::rotations::RotationVector;
 
     // Translation
 

--- a/test/OpenSpaceToolkit/Mathematics/Geometry/3D/Objects/Line.test.cpp
+++ b/test/OpenSpaceToolkit/Mathematics/Geometry/3D/Objects/Line.test.cpp
@@ -433,7 +433,7 @@ TEST(OpenSpaceToolkit_Mathematics_Geometry_3D_Objects_Line, ApplyTransformation)
     using ostk::math::geometry::Angle;
     using ostk::math::geometry::d3::objects::Line;
     using ostk::math::geometry::d3::Transformation;
-    using ostk::math::geometry::d3::trf::rot::RotationVector;
+    using ostk::math::geometry::d3::transformations::rotations::RotationVector;
 
     // Translation
 

--- a/test/OpenSpaceToolkit/Mathematics/Geometry/3D/Objects/LineString.test.cpp
+++ b/test/OpenSpaceToolkit/Mathematics/Geometry/3D/Objects/LineString.test.cpp
@@ -292,7 +292,7 @@ TEST(OpenSpaceToolkit_Mathematics_Geometry_3D_Objects_LineString, ApplyTransform
     using ostk::math::geometry::d3::objects::Point;
     using ostk::math::geometry::d3::objects::LineString;
     using ostk::math::geometry::d3::Transformation;
-    using ostk::math::geometry::d3::trf::rot::RotationVector;
+    using ostk::math::geometry::d3::transformations::rotations::RotationVector;
 
     // Translation
 

--- a/test/OpenSpaceToolkit/Mathematics/Geometry/3D/Objects/Plane.test.cpp
+++ b/test/OpenSpaceToolkit/Mathematics/Geometry/3D/Objects/Plane.test.cpp
@@ -581,7 +581,7 @@ TEST(OpenSpaceToolkit_Mathematics_Geometry_3D_Objects_Plane, ApplyTransformation
     using ostk::math::geometry::Angle;
     using ostk::math::geometry::d3::objects::Plane;
     using ostk::math::geometry::d3::Transformation;
-    using ostk::math::geometry::d3::trf::rot::RotationVector;
+    using ostk::math::geometry::d3::transformations::rotations::RotationVector;
 
     // Translation
 

--- a/test/OpenSpaceToolkit/Mathematics/Geometry/3D/Objects/Point.test.cpp
+++ b/test/OpenSpaceToolkit/Mathematics/Geometry/3D/Objects/Point.test.cpp
@@ -227,7 +227,7 @@ TEST(OpenSpaceToolkit_Mathematics_Geometry_3D_Objects_Point, ApplyTransformation
     using ostk::math::geometry::Angle;
     using ostk::math::geometry::d3::objects::Point;
     using ostk::math::geometry::d3::Transformation;
-    using ostk::math::geometry::d3::trf::rot::RotationVector;
+    using ostk::math::geometry::d3::transformations::rotations::RotationVector;
 
     // Translation
 

--- a/test/OpenSpaceToolkit/Mathematics/Geometry/3D/Objects/PointSet.test.cpp
+++ b/test/OpenSpaceToolkit/Mathematics/Geometry/3D/Objects/PointSet.test.cpp
@@ -316,7 +316,7 @@ TEST(OpenSpaceToolkit_Mathematics_Geometry_3D_Objects_PointSet, ApplyTransformat
     using ostk::math::geometry::d3::objects::Point;
     using ostk::math::geometry::d3::objects::PointSet;
     using ostk::math::geometry::d3::Transformation;
-    using ostk::math::geometry::d3::trf::rot::RotationVector;
+    using ostk::math::geometry::d3::transformations::rotations::RotationVector;
 
     // Translation
 

--- a/test/OpenSpaceToolkit/Mathematics/Geometry/3D/Objects/Polygon.test.cpp
+++ b/test/OpenSpaceToolkit/Mathematics/Geometry/3D/Objects/Polygon.test.cpp
@@ -330,7 +330,7 @@ TEST(OpenSpaceToolkit_Mathematics_Geometry_3D_Objects_Polygon, ApplyTransformati
     using ostk::math::geometry::d3::objects::Point;
     using ostk::math::geometry::d3::objects::Polygon;
     using ostk::math::geometry::d3::Transformation;
-    using ostk::math::geometry::d3::trf::rot::RotationVector;
+    using ostk::math::geometry::d3::transformations::rotations::RotationVector;
 
     // Translation
 

--- a/test/OpenSpaceToolkit/Mathematics/Geometry/3D/Objects/Pyramid.test.cpp
+++ b/test/OpenSpaceToolkit/Mathematics/Geometry/3D/Objects/Pyramid.test.cpp
@@ -448,7 +448,7 @@ TEST(OpenSpaceToolkit_Mathematics_Geometry_3D_Objects_Pyramid, ApplyTransformati
     using ostk::math::geometry::d3::objects::Polygon;
     using ostk::math::geometry::d3::objects::Pyramid;
     using ostk::math::geometry::d3::Transformation;
-    using ostk::math::geometry::d3::trf::rot::RotationVector;
+    using ostk::math::geometry::d3::transformations::rotations::RotationVector;
 
     // Translation
 

--- a/test/OpenSpaceToolkit/Mathematics/Geometry/3D/Objects/Ray.test.cpp
+++ b/test/OpenSpaceToolkit/Mathematics/Geometry/3D/Objects/Ray.test.cpp
@@ -428,7 +428,7 @@ TEST(OpenSpaceToolkit_Mathematics_Geometry_3D_Objects_Ray, ApplyTransformation)
     using ostk::math::geometry::Angle;
     using ostk::math::geometry::d3::objects::Ray;
     using ostk::math::geometry::d3::Transformation;
-    using ostk::math::geometry::d3::trf::rot::RotationVector;
+    using ostk::math::geometry::d3::transformations::rotations::RotationVector;
 
     // Translation
 

--- a/test/OpenSpaceToolkit/Mathematics/Geometry/3D/Objects/Segment.test.cpp
+++ b/test/OpenSpaceToolkit/Mathematics/Geometry/3D/Objects/Segment.test.cpp
@@ -470,7 +470,7 @@ TEST(OpenSpaceToolkit_Mathematics_Geometry_3D_Objects_Segment, ApplyTransformati
     using ostk::math::geometry::Angle;
     using ostk::math::geometry::d3::objects::Segment;
     using ostk::math::geometry::d3::Transformation;
-    using ostk::math::geometry::d3::trf::rot::RotationVector;
+    using ostk::math::geometry::d3::transformations::rotations::RotationVector;
 
     // Translation
 

--- a/test/OpenSpaceToolkit/Mathematics/Geometry/3D/Objects/Sphere.test.cpp
+++ b/test/OpenSpaceToolkit/Mathematics/Geometry/3D/Objects/Sphere.test.cpp
@@ -802,7 +802,7 @@ TEST(OpenSpaceToolkit_Mathematics_Geometry_3D_Objects_Sphere, ApplyTransformatio
     using ostk::math::geometry::Angle;
     using ostk::math::geometry::d3::objects::Sphere;
     using ostk::math::geometry::d3::Transformation;
-    using ostk::math::geometry::d3::trf::rot::RotationVector;
+    using ostk::math::geometry::d3::transformations::rotations::RotationVector;
 
     // Translation
 

--- a/test/OpenSpaceToolkit/Mathematics/Geometry/3D/Transformation.test.cpp
+++ b/test/OpenSpaceToolkit/Mathematics/Geometry/3D/Transformation.test.cpp
@@ -222,7 +222,7 @@ TEST(OpenSpaceToolkit_Mathematics_Geometry_3D_Transformation, RotationAround)
     using ostk::math::geometry::Angle;
     using ostk::math::geometry::d3::objects::Point;
     using ostk::math::geometry::d3::Transformation;
-    using ostk::math::geometry::d3::trf::rot::RotationVector;
+    using ostk::math::geometry::d3::transformations::rotations::RotationVector;
 
     {
         const Point rotationCenter = {0.0, 0.0, 0.0};

--- a/test/OpenSpaceToolkit/Mathematics/Geometry/3D/Transformations/Rotations/Quaternion.test.cpp
+++ b/test/OpenSpaceToolkit/Mathematics/Geometry/3D/Transformations/Rotations/Quaternion.test.cpp
@@ -12,7 +12,7 @@ TEST(OpenSpaceToolkit_Mathematics_Geometry_3D_Transformations_Rotations_Quaterni
 {
     using ostk::math::object::Vector3d;
     using ostk::math::object::Vector4d;
-    using ostk::math::geometry::d3::trf::rot::Quaternion;
+    using ostk::math::geometry::d3::transformations::rotations::Quaternion;
 
     {
         EXPECT_NO_THROW(Quaternion(0.0, 0.0, 0.0, 1.0, Quaternion::Format::XYZS));
@@ -41,7 +41,7 @@ TEST(OpenSpaceToolkit_Mathematics_Geometry_3D_Transformations_Rotations_Quaterni
 
 TEST(OpenSpaceToolkit_Mathematics_Geometry_3D_Transformations_Rotations_Quaternion, EqualToOperator)
 {
-    using ostk::math::geometry::d3::trf::rot::Quaternion;
+    using ostk::math::geometry::d3::transformations::rotations::Quaternion;
 
     {
         EXPECT_TRUE(
@@ -120,7 +120,7 @@ TEST(OpenSpaceToolkit_Mathematics_Geometry_3D_Transformations_Rotations_Quaterni
 
 TEST(OpenSpaceToolkit_Mathematics_Geometry_3D_Transformations_Rotations_Quaternion, NotEqualToOperator)
 {
-    using ostk::math::geometry::d3::trf::rot::Quaternion;
+    using ostk::math::geometry::d3::transformations::rotations::Quaternion;
 
     {
         EXPECT_TRUE(
@@ -199,7 +199,7 @@ TEST(OpenSpaceToolkit_Mathematics_Geometry_3D_Transformations_Rotations_Quaterni
 
 TEST(OpenSpaceToolkit_Mathematics_Geometry_3D_Transformations_Rotations_Quaternion, AdditionOperator)
 {
-    using ostk::math::geometry::d3::trf::rot::Quaternion;
+    using ostk::math::geometry::d3::transformations::rotations::Quaternion;
 
     {
         EXPECT_EQ(
@@ -216,7 +216,7 @@ TEST(OpenSpaceToolkit_Mathematics_Geometry_3D_Transformations_Rotations_Quaterni
 
 TEST(OpenSpaceToolkit_Mathematics_Geometry_3D_Transformations_Rotations_Quaternion, MultiplicationOperator_Quaternion)
 {
-    using ostk::math::geometry::d3::trf::rot::Quaternion;
+    using ostk::math::geometry::d3::transformations::rotations::Quaternion;
 
     {
         EXPECT_EQ(Quaternion::Unit(), Quaternion::Unit() * Quaternion::Unit());
@@ -231,7 +231,7 @@ TEST(OpenSpaceToolkit_Mathematics_Geometry_3D_Transformations_Rotations_Quaterni
 TEST(OpenSpaceToolkit_Mathematics_Geometry_3D_Transformations_Rotations_Quaternion, MultiplicationOperator_Vector3d)
 {
     using ostk::math::object::Vector3d;
-    using ostk::math::geometry::d3::trf::rot::Quaternion;
+    using ostk::math::geometry::d3::transformations::rotations::Quaternion;
 
     {
         EXPECT_EQ(Vector3d::X(), Quaternion::Unit() * Vector3d::X());
@@ -247,7 +247,7 @@ TEST(OpenSpaceToolkit_Mathematics_Geometry_3D_Transformations_Rotations_Quaterni
 {
     using ostk::core::types::Real;
 
-    using ostk::math::geometry::d3::trf::rot::Quaternion;
+    using ostk::math::geometry::d3::transformations::rotations::Quaternion;
 
     {
         EXPECT_EQ(Quaternion::Unit(), Quaternion::Unit() * 1.0);
@@ -266,7 +266,7 @@ TEST(OpenSpaceToolkit_Mathematics_Geometry_3D_Transformations_Rotations_Quaterni
 // TEST (OpenSpaceToolkit_Mathematics_Geometry_3D_Transformations_Rotations_Quaternion, DivisionOperator)
 // {
 
-//     using ostk::math::geometry::d3::trf::rot::Quaternion ;
+//     using ostk::math::geometry::d3::transformations::rotations::Quaternion ;
 
 //     {
 
@@ -281,7 +281,7 @@ TEST(OpenSpaceToolkit_Mathematics_Geometry_3D_Transformations_Rotations_Quaterni
     using ostk::core::types::Real;
 
     using ostk::math::geometry::Angle;
-    using ostk::math::geometry::d3::trf::rot::Quaternion;
+    using ostk::math::geometry::d3::transformations::rotations::Quaternion;
 
     {
         EXPECT_EQ(Quaternion::Unit(), Quaternion::Unit() ^ 1.0);
@@ -299,7 +299,7 @@ TEST(OpenSpaceToolkit_Mathematics_Geometry_3D_Transformations_Rotations_Quaterni
 // MultiplicationAssignmentOperator)
 // {
 
-//     using ostk::math::geometry::d3::trf::rot::Quaternion ;
+//     using ostk::math::geometry::d3::transformations::rotations::Quaternion ;
 
 //     {
 
@@ -312,7 +312,7 @@ TEST(OpenSpaceToolkit_Mathematics_Geometry_3D_Transformations_Rotations_Quaterni
 // TEST (OpenSpaceToolkit_Mathematics_Geometry_3D_Transformations_Rotations_Quaternion, DivisionAssignmentOperator)
 // {
 
-//     using ostk::math::geometry::d3::trf::rot::Quaternion ;
+//     using ostk::math::geometry::d3::transformations::rotations::Quaternion ;
 
 //     {
 
@@ -324,7 +324,7 @@ TEST(OpenSpaceToolkit_Mathematics_Geometry_3D_Transformations_Rotations_Quaterni
 
 TEST(OpenSpaceToolkit_Mathematics_Geometry_3D_Transformations_Rotations_Quaternion, StreamOperator)
 {
-    using ostk::math::geometry::d3::trf::rot::Quaternion;
+    using ostk::math::geometry::d3::transformations::rotations::Quaternion;
 
     {
         testing::internal::CaptureStdout();
@@ -337,7 +337,7 @@ TEST(OpenSpaceToolkit_Mathematics_Geometry_3D_Transformations_Rotations_Quaterni
 
 TEST(OpenSpaceToolkit_Mathematics_Geometry_3D_Transformations_Rotations_Quaternion, IsDefined)
 {
-    using ostk::math::geometry::d3::trf::rot::Quaternion;
+    using ostk::math::geometry::d3::transformations::rotations::Quaternion;
 
     {
         EXPECT_TRUE(Quaternion::XYZS(1.0, 0.0, 0.0, 0.0).isDefined());
@@ -357,7 +357,7 @@ TEST(OpenSpaceToolkit_Mathematics_Geometry_3D_Transformations_Rotations_Quaterni
 
 TEST(OpenSpaceToolkit_Mathematics_Geometry_3D_Transformations_Rotations_Quaternion, IsUnitary)
 {
-    using ostk::math::geometry::d3::trf::rot::Quaternion;
+    using ostk::math::geometry::d3::transformations::rotations::Quaternion;
 
     {
         EXPECT_TRUE(Quaternion::XYZS(1.0, 0.0, 0.0, 0.0).isUnitary());
@@ -378,7 +378,7 @@ TEST(OpenSpaceToolkit_Mathematics_Geometry_3D_Transformations_Rotations_Quaterni
 TEST(OpenSpaceToolkit_Mathematics_Geometry_3D_Transformations_Rotations_Quaternion, IsNear)
 {
     using ostk::math::geometry::Angle;
-    using ostk::math::geometry::d3::trf::rot::Quaternion;
+    using ostk::math::geometry::d3::transformations::rotations::Quaternion;
 
     {
         EXPECT_TRUE(Quaternion::XYZS(1.0, 0.0, 0.0, 0.0).isNear(Quaternion::XYZS(1.0, 0.0, 0.0, 0.0), Angle::Zero()));
@@ -422,7 +422,7 @@ TEST(OpenSpaceToolkit_Mathematics_Geometry_3D_Transformations_Rotations_Quaterni
 
 TEST(OpenSpaceToolkit_Mathematics_Geometry_3D_Transformations_Rotations_Quaternion, X)
 {
-    using ostk::math::geometry::d3::trf::rot::Quaternion;
+    using ostk::math::geometry::d3::transformations::rotations::Quaternion;
 
     {
         EXPECT_EQ(1.0, Quaternion::XYZS(1.0, 2.0, 3.0, 4.0).x());
@@ -435,7 +435,7 @@ TEST(OpenSpaceToolkit_Mathematics_Geometry_3D_Transformations_Rotations_Quaterni
 
 TEST(OpenSpaceToolkit_Mathematics_Geometry_3D_Transformations_Rotations_Quaternion, Y)
 {
-    using ostk::math::geometry::d3::trf::rot::Quaternion;
+    using ostk::math::geometry::d3::transformations::rotations::Quaternion;
 
     {
         EXPECT_EQ(2.0, Quaternion::XYZS(1.0, 2.0, 3.0, 4.0).y());
@@ -448,7 +448,7 @@ TEST(OpenSpaceToolkit_Mathematics_Geometry_3D_Transformations_Rotations_Quaterni
 
 TEST(OpenSpaceToolkit_Mathematics_Geometry_3D_Transformations_Rotations_Quaternion, Z)
 {
-    using ostk::math::geometry::d3::trf::rot::Quaternion;
+    using ostk::math::geometry::d3::transformations::rotations::Quaternion;
 
     {
         EXPECT_EQ(3.0, Quaternion::XYZS(1.0, 2.0, 3.0, 4.0).z());
@@ -461,7 +461,7 @@ TEST(OpenSpaceToolkit_Mathematics_Geometry_3D_Transformations_Rotations_Quaterni
 
 TEST(OpenSpaceToolkit_Mathematics_Geometry_3D_Transformations_Rotations_Quaternion, S)
 {
-    using ostk::math::geometry::d3::trf::rot::Quaternion;
+    using ostk::math::geometry::d3::transformations::rotations::Quaternion;
 
     {
         EXPECT_EQ(4.0, Quaternion::XYZS(1.0, 2.0, 3.0, 4.0).s());
@@ -475,7 +475,7 @@ TEST(OpenSpaceToolkit_Mathematics_Geometry_3D_Transformations_Rotations_Quaterni
 TEST(OpenSpaceToolkit_Mathematics_Geometry_3D_Transformations_Rotations_Quaternion, GetVectorPart)
 {
     using ostk::math::object::Vector3d;
-    using ostk::math::geometry::d3::trf::rot::Quaternion;
+    using ostk::math::geometry::d3::transformations::rotations::Quaternion;
 
     {
         EXPECT_EQ(Vector3d(1.0, 2.0, 3.0), Quaternion::XYZS(1.0, 2.0, 3.0, 4.0).getVectorPart());
@@ -488,7 +488,7 @@ TEST(OpenSpaceToolkit_Mathematics_Geometry_3D_Transformations_Rotations_Quaterni
 
 TEST(OpenSpaceToolkit_Mathematics_Geometry_3D_Transformations_Rotations_Quaternion, GetScalarPart)
 {
-    using ostk::math::geometry::d3::trf::rot::Quaternion;
+    using ostk::math::geometry::d3::transformations::rotations::Quaternion;
 
     {
         EXPECT_EQ(4.0, Quaternion::XYZS(1.0, 2.0, 3.0, 4.0).getScalarPart());
@@ -502,7 +502,7 @@ TEST(OpenSpaceToolkit_Mathematics_Geometry_3D_Transformations_Rotations_Quaterni
 // TEST (OpenSpaceToolkit_Mathematics_Geometry_3D_Transformations_Rotations_Quaternion, ToNormalized)
 // {
 
-//     using ostk::math::geometry::d3::trf::rot::Quaternion ;
+//     using ostk::math::geometry::d3::transformations::rotations::Quaternion ;
 
 //     {
 
@@ -514,7 +514,7 @@ TEST(OpenSpaceToolkit_Mathematics_Geometry_3D_Transformations_Rotations_Quaterni
 
 TEST(OpenSpaceToolkit_Mathematics_Geometry_3D_Transformations_Rotations_Quaternion, ToConjugate)
 {
-    using ostk::math::geometry::d3::trf::rot::Quaternion;
+    using ostk::math::geometry::d3::transformations::rotations::Quaternion;
 
     {
         EXPECT_EQ(Quaternion::XYZS(-1.0, -2.0, -3.0, +4.0), Quaternion::XYZS(+1.0, +2.0, +3.0, +4.0).toConjugate());
@@ -532,7 +532,7 @@ TEST(OpenSpaceToolkit_Mathematics_Geometry_3D_Transformations_Rotations_Quaterni
 // TEST (OpenSpaceToolkit_Mathematics_Geometry_3D_Transformations_Rotations_Quaternion, ToInverse)
 // {
 
-//     using ostk::math::geometry::d3::trf::rot::Quaternion ;
+//     using ostk::math::geometry::d3::transformations::rotations::Quaternion ;
 
 //     {
 
@@ -545,7 +545,7 @@ TEST(OpenSpaceToolkit_Mathematics_Geometry_3D_Transformations_Rotations_Quaterni
 TEST(OpenSpaceToolkit_Mathematics_Geometry_3D_Transformations_Rotations_Quaternion, Exp)
 {
     using ostk::math::geometry::Angle;
-    using ostk::math::geometry::d3::trf::rot::Quaternion;
+    using ostk::math::geometry::d3::transformations::rotations::Quaternion;
 
     {
         EXPECT_EQ(Quaternion::Unit(), Quaternion::Unit().exp());
@@ -563,7 +563,7 @@ TEST(OpenSpaceToolkit_Mathematics_Geometry_3D_Transformations_Rotations_Quaterni
 TEST(OpenSpaceToolkit_Mathematics_Geometry_3D_Transformations_Rotations_Quaternion, Log)
 {
     using ostk::math::geometry::Angle;
-    using ostk::math::geometry::d3::trf::rot::Quaternion;
+    using ostk::math::geometry::d3::transformations::rotations::Quaternion;
 
     {
         EXPECT_EQ(Quaternion({0.0, 0.0, 0.0}, 0.0), Quaternion::Unit().log());
@@ -583,7 +583,7 @@ TEST(OpenSpaceToolkit_Mathematics_Geometry_3D_Transformations_Rotations_Quaterni
     using ostk::core::types::Real;
 
     using ostk::math::geometry::Angle;
-    using ostk::math::geometry::d3::trf::rot::Quaternion;
+    using ostk::math::geometry::d3::transformations::rotations::Quaternion;
 
     {
         EXPECT_EQ(Quaternion::Unit(), Quaternion::Unit().pow(1.0));
@@ -601,7 +601,7 @@ TEST(OpenSpaceToolkit_Mathematics_Geometry_3D_Transformations_Rotations_Quaterni
 // TEST (OpenSpaceToolkit_Mathematics_Geometry_3D_Transformations_Rotations_Quaternion, Norm)
 // {
 
-//     using ostk::math::geometry::d3::trf::rot::Quaternion ;
+//     using ostk::math::geometry::d3::transformations::rotations::Quaternion ;
 
 //     {
 
@@ -614,7 +614,7 @@ TEST(OpenSpaceToolkit_Mathematics_Geometry_3D_Transformations_Rotations_Quaterni
 // TEST (OpenSpaceToolkit_Mathematics_Geometry_3D_Transformations_Rotations_Quaternion, CrossMultiply)
 // {
 
-//     using ostk::math::geometry::d3::trf::rot::Quaternion ;
+//     using ostk::math::geometry::d3::transformations::rotations::Quaternion ;
 
 //     {
 
@@ -627,7 +627,7 @@ TEST(OpenSpaceToolkit_Mathematics_Geometry_3D_Transformations_Rotations_Quaterni
 // TEST (OpenSpaceToolkit_Mathematics_Geometry_3D_Transformations_Rotations_Quaternion, DotMultiply)
 // {
 
-//     using ostk::math::geometry::d3::trf::rot::Quaternion ;
+//     using ostk::math::geometry::d3::transformations::rotations::Quaternion ;
 
 //     {
 
@@ -640,7 +640,7 @@ TEST(OpenSpaceToolkit_Mathematics_Geometry_3D_Transformations_Rotations_Quaterni
 // TEST (OpenSpaceToolkit_Mathematics_Geometry_3D_Transformations_Rotations_Quaternion, RotateVector)
 // {
 
-//     using ostk::math::geometry::d3::trf::rot::Quaternion ;
+//     using ostk::math::geometry::d3::transformations::rotations::Quaternion ;
 
 //     {
 
@@ -653,7 +653,7 @@ TEST(OpenSpaceToolkit_Mathematics_Geometry_3D_Transformations_Rotations_Quaterni
 TEST(OpenSpaceToolkit_Mathematics_Geometry_3D_Transformations_Rotations_Quaternion, ToVector)
 {
     using ostk::math::object::Vector4d;
-    using ostk::math::geometry::d3::trf::rot::Quaternion;
+    using ostk::math::geometry::d3::transformations::rotations::Quaternion;
 
     {
         EXPECT_EQ(
@@ -671,7 +671,7 @@ TEST(OpenSpaceToolkit_Mathematics_Geometry_3D_Transformations_Rotations_Quaterni
 
 TEST(OpenSpaceToolkit_Mathematics_Geometry_3D_Transformations_Rotations_Quaternion, ToString)
 {
-    using ostk::math::geometry::d3::trf::rot::Quaternion;
+    using ostk::math::geometry::d3::transformations::rotations::Quaternion;
 
     {
         EXPECT_EQ("[0.0, 0.0, 0.0, 1.0]", Quaternion::XYZS(0.0, 0.0, 0.0, 1.0).toString(Quaternion::Format::XYZS));
@@ -702,7 +702,7 @@ TEST(OpenSpaceToolkit_Mathematics_Geometry_3D_Transformations_Rotations_Quaterni
 // TEST (OpenSpaceToolkit_Mathematics_Geometry_3D_Transformations_Rotations_Quaternion, Normalize)
 // {
 
-//     using ostk::math::geometry::d3::trf::rot::Quaternion ;
+//     using ostk::math::geometry::d3::transformations::rotations::Quaternion ;
 
 //     {
 
@@ -715,7 +715,7 @@ TEST(OpenSpaceToolkit_Mathematics_Geometry_3D_Transformations_Rotations_Quaterni
 // TEST (OpenSpaceToolkit_Mathematics_Geometry_3D_Transformations_Rotations_Quaternion, Conjugate)
 // {
 
-//     using ostk::math::geometry::d3::trf::rot::Quaternion ;
+//     using ostk::math::geometry::d3::transformations::rotations::Quaternion ;
 
 //     {
 
@@ -728,7 +728,7 @@ TEST(OpenSpaceToolkit_Mathematics_Geometry_3D_Transformations_Rotations_Quaterni
 // TEST (OpenSpaceToolkit_Mathematics_Geometry_3D_Transformations_Rotations_Quaternion, Inverse)
 // {
 
-//     using ostk::math::geometry::d3::trf::rot::Quaternion ;
+//     using ostk::math::geometry::d3::transformations::rotations::Quaternion ;
 
 //     {
 
@@ -741,7 +741,7 @@ TEST(OpenSpaceToolkit_Mathematics_Geometry_3D_Transformations_Rotations_Quaterni
 // TEST (OpenSpaceToolkit_Mathematics_Geometry_3D_Transformations_Rotations_Quaternion, Rectify)
 // {
 
-//     using ostk::math::geometry::d3::trf::rot::Quaternion ;
+//     using ostk::math::geometry::d3::transformations::rotations::Quaternion ;
 
 //     {
 
@@ -754,7 +754,7 @@ TEST(OpenSpaceToolkit_Mathematics_Geometry_3D_Transformations_Rotations_Quaterni
 TEST(OpenSpaceToolkit_Mathematics_Geometry_3D_Transformations_Rotations_Quaternion, AngularDifferenceWith)
 {
     using ostk::math::geometry::Angle;
-    using ostk::math::geometry::d3::trf::rot::Quaternion;
+    using ostk::math::geometry::d3::transformations::rotations::Quaternion;
 
     {
         EXPECT_EQ(Angle::Zero(), Quaternion::Unit().angularDifferenceWith(Quaternion::Unit()));
@@ -781,7 +781,7 @@ TEST(OpenSpaceToolkit_Mathematics_Geometry_3D_Transformations_Rotations_Quaterni
 
 TEST(OpenSpaceToolkit_Mathematics_Geometry_3D_Transformations_Rotations_Quaternion, Undefined)
 {
-    using ostk::math::geometry::d3::trf::rot::Quaternion;
+    using ostk::math::geometry::d3::transformations::rotations::Quaternion;
 
     {
         EXPECT_NO_THROW(Quaternion::Undefined());
@@ -791,7 +791,7 @@ TEST(OpenSpaceToolkit_Mathematics_Geometry_3D_Transformations_Rotations_Quaterni
 
 TEST(OpenSpaceToolkit_Mathematics_Geometry_3D_Transformations_Rotations_Quaternion, Unit)
 {
-    using ostk::math::geometry::d3::trf::rot::Quaternion;
+    using ostk::math::geometry::d3::transformations::rotations::Quaternion;
 
     {
         EXPECT_NO_THROW(Quaternion::Unit());
@@ -801,7 +801,7 @@ TEST(OpenSpaceToolkit_Mathematics_Geometry_3D_Transformations_Rotations_Quaterni
 
 TEST(OpenSpaceToolkit_Mathematics_Geometry_3D_Transformations_Rotations_Quaternion, XYZS)
 {
-    using ostk::math::geometry::d3::trf::rot::Quaternion;
+    using ostk::math::geometry::d3::transformations::rotations::Quaternion;
 
     {
         EXPECT_NO_THROW(Quaternion::XYZS(0.0, 0.0, 0.0, 1.0));
@@ -814,8 +814,8 @@ TEST(OpenSpaceToolkit_Mathematics_Geometry_3D_Transformations_Rotations_Quaterni
     using ostk::core::types::Real;
 
     using ostk::math::geometry::Angle;
-    using ostk::math::geometry::d3::trf::rot::RotationVector;
-    using ostk::math::geometry::d3::trf::rot::Quaternion;
+    using ostk::math::geometry::d3::transformations::rotations::RotationVector;
+    using ostk::math::geometry::d3::transformations::rotations::Quaternion;
 
     {
         EXPECT_TRUE(Quaternion(0.0, 0.0, 0.0, 1.0, Quaternion::Format::XYZS)
@@ -841,9 +841,9 @@ TEST(OpenSpaceToolkit_Mathematics_Geometry_3D_Transformations_Rotations_Quaterni
 
     using ostk::math::object::Vector3d;
     using ostk::math::geometry::Angle;
-    using ostk::math::geometry::d3::trf::rot::RotationVector;
-    using ostk::math::geometry::d3::trf::rot::RotationMatrix;
-    using ostk::math::geometry::d3::trf::rot::Quaternion;
+    using ostk::math::geometry::d3::transformations::rotations::RotationVector;
+    using ostk::math::geometry::d3::transformations::rotations::RotationMatrix;
+    using ostk::math::geometry::d3::transformations::rotations::Quaternion;
 
     {
         EXPECT_TRUE(Quaternion(0.0, 0.0, 0.0, 1.0, Quaternion::Format::XYZS)
@@ -889,7 +889,7 @@ TEST(OpenSpaceToolkit_Mathematics_Geometry_3D_Transformations_Rotations_Quaterni
 
 TEST(OpenSpaceToolkit_Mathematics_Geometry_3D_Transformations_Rotations_Quaternion, Parse)
 {
-    using ostk::math::geometry::d3::trf::rot::Quaternion;
+    using ostk::math::geometry::d3::transformations::rotations::Quaternion;
 
     {
         EXPECT_NO_THROW(Quaternion::Parse("[0.0, 0.0, 0.0, 1.0]", Quaternion::Format::XYZS));
@@ -915,8 +915,8 @@ TEST(OpenSpaceToolkit_Mathematics_Geometry_3D_Transformations_Rotations_Quaterni
 {
     using ostk::math::object::Vector3d;
     using ostk::math::geometry::Angle;
-    using ostk::math::geometry::d3::trf::rot::Quaternion;
-    using ostk::math::geometry::d3::trf::rot::RotationVector;
+    using ostk::math::geometry::d3::transformations::rotations::Quaternion;
+    using ostk::math::geometry::d3::transformations::rotations::RotationVector;
 
     {
         EXPECT_TRUE(Quaternion::ShortestRotation({1.0, 0.0, 0.0}, {1.0, 0.0, 0.0})
@@ -948,8 +948,8 @@ TEST(OpenSpaceToolkit_Mathematics_Geometry_3D_Transformations_Rotations_Quaterni
     using ostk::core::types::Real;
 
     using ostk::math::geometry::Angle;
-    using ostk::math::geometry::d3::trf::rot::Quaternion;
-    using ostk::math::geometry::d3::trf::rot::RotationVector;
+    using ostk::math::geometry::d3::transformations::rotations::Quaternion;
+    using ostk::math::geometry::d3::transformations::rotations::RotationVector;
 
     {
         EXPECT_TRUE(Quaternion::LERP(Quaternion::XYZS(0.0, 0.0, 0.0, 1.0), Quaternion::XYZS(0.0, 0.0, 1.0, 0.0), 0.0)
@@ -973,8 +973,8 @@ TEST(OpenSpaceToolkit_Mathematics_Geometry_3D_Transformations_Rotations_Quaterni
     using ostk::core::types::Real;
 
     using ostk::math::geometry::Angle;
-    using ostk::math::geometry::d3::trf::rot::Quaternion;
-    using ostk::math::geometry::d3::trf::rot::RotationVector;
+    using ostk::math::geometry::d3::transformations::rotations::Quaternion;
+    using ostk::math::geometry::d3::transformations::rotations::RotationVector;
 
     {
         EXPECT_TRUE(Quaternion::NLERP(Quaternion::XYZS(0.0, 0.0, 0.0, 1.0), Quaternion::XYZS(0.0, 0.0, 1.0, 0.0), 0.0)
@@ -1008,8 +1008,8 @@ TEST(OpenSpaceToolkit_Mathematics_Geometry_3D_Transformations_Rotations_Quaterni
     using ostk::core::types::Real;
 
     using ostk::math::geometry::Angle;
-    using ostk::math::geometry::d3::trf::rot::Quaternion;
-    using ostk::math::geometry::d3::trf::rot::RotationVector;
+    using ostk::math::geometry::d3::transformations::rotations::Quaternion;
+    using ostk::math::geometry::d3::transformations::rotations::RotationVector;
 
     {
         EXPECT_TRUE(Quaternion::SLERP(Quaternion::XYZS(0.0, 0.0, 0.0, 1.0), Quaternion::XYZS(0.0, 0.0, 1.0, 0.0), 0.0)

--- a/test/OpenSpaceToolkit/Mathematics/Geometry/3D/Transformations/Rotations/RotationMatrix.test.cpp
+++ b/test/OpenSpaceToolkit/Mathematics/Geometry/3D/Transformations/Rotations/RotationMatrix.test.cpp
@@ -10,7 +10,7 @@
 TEST(OpenSpaceToolkit_Mathematics_Geometry_3D_Transformations_Rotations_RotationMatrix, Constructor)
 {
     using ostk::math::geometry::Angle;
-    using ostk::math::geometry::d3::trf::rot::RotationMatrix;
+    using ostk::math::geometry::d3::transformations::rotations::RotationMatrix;
 
     // {
 
@@ -38,7 +38,7 @@ TEST(OpenSpaceToolkit_Mathematics_Geometry_3D_Transformations_Rotations_Rotation
 // {
 
 //     using ostk::math::geometry::Angle ;
-//     using ostk::math::geometry::d3::trf::rot::RotationMatrix ;
+//     using ostk::math::geometry::d3::transformations::rotations::RotationMatrix ;
 
 //     {
 
@@ -81,7 +81,7 @@ TEST(OpenSpaceToolkit_Mathematics_Geometry_3D_Transformations_Rotations_Rotation
 // {
 
 //     using ostk::math::geometry::Angle ;
-//     using ostk::math::geometry::d3::trf::rot::RotationMatrix ;
+//     using ostk::math::geometry::d3::transformations::rotations::RotationMatrix ;
 
 //     {
 
@@ -124,7 +124,7 @@ TEST(OpenSpaceToolkit_Mathematics_Geometry_3D_Transformations_Rotations_Rotation
 // {
 
 //     using ostk::math::geometry::Angle ;
-//     using ostk::math::geometry::d3::trf::rot::RotationMatrix ;
+//     using ostk::math::geometry::d3::transformations::rotations::RotationMatrix ;
 
 //     {
 
@@ -143,7 +143,7 @@ TEST(OpenSpaceToolkit_Mathematics_Geometry_3D_Transformations_Rotations_Rotation
 
 //     using ostk::math::object::Vector3d ;
 //     using ostk::math::geometry::Angle ;
-//     using ostk::math::geometry::d3::trf::rot::RotationMatrix ;
+//     using ostk::math::geometry::d3::transformations::rotations::RotationMatrix ;
 
 //     {
 
@@ -166,7 +166,7 @@ TEST(OpenSpaceToolkit_Mathematics_Geometry_3D_Transformations_Rotations_Rotation
 
 //     using ostk::math::object::Vector3d ;
 //     using ostk::math::geometry::Angle ;
-//     using ostk::math::geometry::d3::trf::rot::RotationMatrix ;
+//     using ostk::math::geometry::d3::transformations::rotations::RotationMatrix ;
 
 //     {
 
@@ -188,7 +188,7 @@ TEST(OpenSpaceToolkit_Mathematics_Geometry_3D_Transformations_Rotations_Rotation
 // {
 
 //     using ostk::math::geometry::Angle ;
-//     using ostk::math::geometry::d3::trf::rot::RotationMatrix ;
+//     using ostk::math::geometry::d3::transformations::rotations::RotationMatrix ;
 
 //     {
 
@@ -216,7 +216,7 @@ TEST(OpenSpaceToolkit_Mathematics_Geometry_3D_Transformations_Rotations_Rotation
 // TEST (OpenSpaceToolkit_Mathematics_Geometry_3D_Transformations_Rotations_RotationMatrix, Undefined)
 // {
 
-//     using ostk::math::geometry::d3::trf::rot::RotationMatrix ;
+//     using ostk::math::geometry::d3::transformations::rotations::RotationMatrix ;
 
 //     {
 
@@ -231,7 +231,7 @@ TEST(OpenSpaceToolkit_Mathematics_Geometry_3D_Transformations_Rotations_Rotation
 // {
 
 //     using ostk::math::geometry::Angle ;
-//     using ostk::math::geometry::d3::trf::rot::RotationMatrix ;
+//     using ostk::math::geometry::d3::transformations::rotations::RotationMatrix ;
 
 //     {
 
@@ -251,8 +251,8 @@ TEST(OpenSpaceToolkit_Mathematics_Geometry_3D_Transformations_Rotations_Rotation
 
 //     using ostk::core::types::Real ;
 //     using ostk::math::geometry::Angle ;
-//     using ostk::math::geometry::d3::trf::rot::Quaternion ;
-//     using ostk::math::geometry::d3::trf::rot::RotationMatrix ;
+//     using ostk::math::geometry::d3::transformations::rotations::Quaternion ;
+//     using ostk::math::geometry::d3::transformations::rotations::RotationMatrix ;
 
 //     {
 

--- a/test/OpenSpaceToolkit/Mathematics/Geometry/3D/Transformations/Rotations/RotationVector.test.cpp
+++ b/test/OpenSpaceToolkit/Mathematics/Geometry/3D/Transformations/Rotations/RotationVector.test.cpp
@@ -7,8 +7,8 @@
 #include <Global.test.hpp>
 
 using ostk::math::geometry::Angle;
-using ostk::math::geometry::d3::trf::rot::Quaternion;
-using ostk::math::geometry::d3::trf::rot::RotationVector;
+using ostk::math::geometry::d3::transformations::rotations::Quaternion;
+using ostk::math::geometry::d3::transformations::rotations::RotationVector;
 using ostk::math::object::Vector3d;
 using ostk::core::types::Real;
 


### PR DESCRIPTION
The bindings for these are already using the explicit versions