### PR TITLE
feat: Update stacktrace definitions and platform-specific paths

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -225,7 +225,21 @@ SET (Boost_USE_MULTITHREADED ON)
 
 FIND_PACKAGE ("Boost" "1.82")
 
-ADD_DEFINITIONS(-DBOOST_STACKTRACE_USE_BACKTRACE -DBOOST_STACKTRACE_BACKTRACE_INCLUDE_FILE=</usr/lib/gcc/x86_64-linux-gnu/9/include/backtrace.h>)
+## Stacktrace definitions
+# Detect system architecture
+if(CMAKE_SYSTEM_PROCESSOR MATCHES "x86_64")
+    # Architecture-specific include for x86_64
+    set(BACKTRACE_INCLUDE "/usr/lib/gcc/x86_64-linux-gnu/9/include/backtrace.h")
+elseif(CMAKE_SYSTEM_PROCESSOR MATCHES "aarch64")
+    # Example path adjustment for aarch64, adjust the path as needed
+    set(BACKTRACE_INCLUDE "/usr/lib/gcc/aarch64-linux-gnu/9/include/backtrace.h")
+else()
+    message(FATAL_ERROR "Unsupported architecture: ${CMAKE_SYSTEM_PROCESSOR}")
+endif()
+
+# Add definitions with architecture-specific path
+ADD_DEFINITIONS(-DBOOST_STACKTRACE_USE_BACKTRACE)
+ADD_DEFINITIONS(-DBOOST_STACKTRACE_BACKTRACE_INCLUDE_FILE=<${BACKTRACE_INCLUDE}>)
 
 IF (NOT Boost_FOUND)
     MESSAGE (SEND_ERROR "[Boost] not found.")
@@ -253,9 +267,9 @@ ENDIF ()
 
 # INCLUDE_DIRECTORIES ("/usr/local/include/Gte")  # This thing was already commented out
 
-### Open Space Toolkit ▸ Core [2.1.x]
+### Open Space Toolkit ▸ Core [2.2.x]
 
-FIND_PACKAGE ("OpenSpaceToolkitCore" "2.1" REQUIRED)
+FIND_PACKAGE ("OpenSpaceToolkitCore" "2.2" REQUIRED)
 
 IF (NOT OpenSpaceToolkitCore_FOUND)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -267,7 +267,7 @@ ENDIF ()
 
 # INCLUDE_DIRECTORIES ("/usr/local/include/Gte")  # This thing was already commented out
 
-### Open Space Toolkit ▸ Core [2.2.x]
+### Open Space Toolkit ▸ Core
 
 FIND_PACKAGE ("OpenSpaceToolkitCore" "2.2" REQUIRED)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -267,9 +267,9 @@ ENDIF ()
 
 # INCLUDE_DIRECTORIES ("/usr/local/include/Gte")  # This thing was already commented out
 
-### Open Space Toolkit ▸ Core
+### Open Space Toolkit ▸ Core [3.0.x]
 
-FIND_PACKAGE ("OpenSpaceToolkitCore" "2.2" REQUIRED)
+FIND_PACKAGE ("OpenSpaceToolkitCore" "3.0" REQUIRED)
 
 IF (NOT OpenSpaceToolkitCore_FOUND)
 

--- a/Makefile
+++ b/Makefile
@@ -22,16 +22,9 @@ extract_python_package_version := $(shell echo $(project_version) | sed 's/-/./'
 dev_username := developer
 
 
-ifeq ($(PLATFORM),amd64)
-platform := x86_64
-endif
-
-ifeq ($(PLATFORM),arm64)
-platform := aarch64
-endif
-
-platform ?= x86_64
-$(info Platform value is $(platform))
+# Handle multi-platform builds locally (CI sets these env vars, but need defaults here)
+TARGETPLATFORM ?= linux/amd64
+$(info Target platform is $(TARGETPLATFORM))
 
 
 pull: ## Pull all images
@@ -226,7 +219,7 @@ build-packages-cpp-standalone: ## Build C++ packages (standalone)
 	@ echo "Building C++ packages..."
 
 	docker run \
-		--platform ${platform} \
+		--platform $(TARGETPLATFORM) \
 		--rm \
 		--volume="$(CURDIR):/app:delegated" \
 		--volume="/app/build" \
@@ -250,7 +243,7 @@ build-packages-python-standalone: ## Build Python packages (standalone)
 	@ echo "Building Python packages..."
 
 	docker run \
-		--platform ${platform} \
+		--platform $(TARGETPLATFORM) \
 		--rm \
 		--volume="$(CURDIR):/app:delegated" \
 		--volume="/app/build" \

--- a/Makefile
+++ b/Makefile
@@ -21,6 +21,7 @@ extract_python_package_version := $(shell echo $(project_version) | sed 's/-/./'
 
 dev_username := developer
 
+
 ifeq ($(PLATFORM),amd64)
 platform := x86_64
 endif
@@ -31,6 +32,7 @@ endif
 
 platform ?= x86_64
 $(info Platform value is $(platform))
+
 
 pull: ## Pull all images
 

--- a/Makefile
+++ b/Makefile
@@ -21,6 +21,17 @@ extract_python_package_version := $(shell echo $(project_version) | sed 's/-/./'
 
 dev_username := developer
 
+ifeq ($(PLATFORM),amd64)
+platform := x86_64
+endif
+
+ifeq ($(PLATFORM),arm64)
+platform := aarch64
+endif
+
+platform ?= x86_64
+$(info Platform value is $(platform))
+
 pull: ## Pull all images
 
 	@ echo "Pulling images..."
@@ -213,6 +224,7 @@ build-packages-cpp-standalone: ## Build C++ packages (standalone)
 	@ echo "Building C++ packages..."
 
 	docker run \
+		--platform ${platform} \
 		--rm \
 		--volume="$(CURDIR):/app:delegated" \
 		--volume="/app/build" \
@@ -236,6 +248,7 @@ build-packages-python-standalone: ## Build Python packages (standalone)
 	@ echo "Building Python packages..."
 
 	docker run \
+		--platform ${platform} \
 		--rm \
 		--volume="$(CURDIR):/app:delegated" \
 		--volume="/app/build" \

--- a/bindings/python/CMakeLists.txt
+++ b/bindings/python/CMakeLists.txt
@@ -122,6 +122,15 @@ FUNCTION (PY_ADD_PACKAGE_DIRECTORY NAME)
     # Package directory name
     SET (PACKAGE_DIRECTORY_NAME ${NAME})
 
+    # Set platforme name for wheel
+    if(CMAKE_SYSTEM_PROCESSOR MATCHES "x86_64")
+        SET (PLATFORM "manylinux2014_x86_64")
+    ELSEIF(CMAKE_SYSTEM_PROCESSOR MATCHES "aarch64")
+        SET (PLATFORM "manylinux2014_aarch64")
+    ELSE()
+        MESSAGE (FATAL_ERROR "Unsupported platform")
+    ENDIF()
+
     # Get python extension for relevant shared library spotting
     STRING (REPLACE "." "" EXTENSION "${PYTHON_VERSION}")
 

--- a/bindings/python/requirements.txt
+++ b/bindings/python/requirements.txt
@@ -2,4 +2,4 @@
 
 numpy>=1.17.4
 
-open-space-toolkit-core~=2.1.0
+open-space-toolkit-core~=2.2.0

--- a/bindings/python/requirements.txt
+++ b/bindings/python/requirements.txt
@@ -2,4 +2,4 @@
 
 numpy>=1.17.4
 
-open-space-toolkit-core~=2.2.0
+open-space-toolkit-core~=3.0.0

--- a/bindings/python/tools/python/setup.cfg.in
+++ b/bindings/python/tools/python/setup.cfg.in
@@ -3,6 +3,7 @@
 [bdist_wheel]
 python-tag=py${EXTENSION}
 bdist-dir=./dist${EXTENSION}
+plat-name=${PLATFORM}
 
 [metadata]
 name = open-space-toolkit-mathematics

--- a/docker/development/Dockerfile
+++ b/docker/development/Dockerfile
@@ -4,7 +4,7 @@ ARG BASE_IMAGE_VERSION="latest"
 
 # General purpose development image (root user)
 
-FROM openspacecollective/open-space-toolkit-base:${BASE_IMAGE_VERSION} as root-user
+FROM openspacecollective/open-space-toolkit-base-development:${BASE_IMAGE_VERSION} as root-user
 
 LABEL maintainer="lucas@loftorbital.com"
 
@@ -56,7 +56,7 @@ RUN git clone --branch ${GEOMETRIC_TOOLS_ENGINE_VERSION} --depth 1 https://githu
 ## Open Space Toolkit ▸ Core
 
 ARG OSTK_CORE_MAJOR="2"
-ARG OSTK_CORE_MINOR="1"
+ARG OSTK_CORE_MINOR="2"
 
 ## Force an image rebuild when new Core patch versions are detected
 ADD https://api.github.com/repos/open-space-collective/open-space-toolkit-core/git/matching-refs/tags/${OSTK_CORE_MAJOR}.${OSTK_CORE_MINOR} /tmp/open-space-toolkit-core/versions.json

--- a/docker/development/Dockerfile
+++ b/docker/development/Dockerfile
@@ -56,6 +56,7 @@ RUN git clone --branch ${GEOMETRIC_TOOLS_ENGINE_VERSION} --depth 1 https://githu
 
 ## Open Space Toolkit ▸ Core
 
+ARG TARGETPLATFORM
 ARG OSTK_CORE_MAJOR="3"
 ARG OSTK_CORE_MINOR="0"
 

--- a/docker/development/Dockerfile
+++ b/docker/development/Dockerfile
@@ -11,6 +11,7 @@ LABEL maintainer="lucas@loftorbital.com"
 # Dependencies
 
 # jq
+
 RUN apt-get update \
  && apt-get install -y jq \
  && rm -rf /var/lib/apt/lists/*

--- a/docker/development/Dockerfile
+++ b/docker/development/Dockerfile
@@ -56,8 +56,8 @@ RUN git clone --branch ${GEOMETRIC_TOOLS_ENGINE_VERSION} --depth 1 https://githu
 
 ## Open Space Toolkit ▸ Core
 
-ARG OSTK_CORE_MAJOR="2"
-ARG OSTK_CORE_MINOR="2"
+ARG OSTK_CORE_MAJOR="3"
+ARG OSTK_CORE_MINOR="0"
 
 ## Force an image rebuild when new Core patch versions are detected
 ADD https://api.github.com/repos/open-space-collective/open-space-toolkit-core/git/matching-refs/tags/${OSTK_CORE_MAJOR}.${OSTK_CORE_MINOR} /tmp/open-space-toolkit-core/versions.json
@@ -65,8 +65,9 @@ ADD https://api.github.com/repos/open-space-collective/open-space-toolkit-core/g
 RUN mkdir -p /tmp/open-space-toolkit-core \
  && cd /tmp/open-space-toolkit-core \
  && export LATEST_PATCH_OF_MINOR=$(jq -r .[-1].ref versions.json | cut -d "/" -f3) \
- && wget --quiet https://github.com/open-space-collective/open-space-toolkit-core/releases/download/${LATEST_PATCH_OF_MINOR}/open-space-toolkit-core-${LATEST_PATCH_OF_MINOR}-1.x86_64-runtime.deb \
- && wget --quiet https://github.com/open-space-collective/open-space-toolkit-core/releases/download/${LATEST_PATCH_OF_MINOR}/open-space-toolkit-core-${LATEST_PATCH_OF_MINOR}-1.x86_64-devel.deb \
+ && export PACKAGE_PLATFORM=$(if [ ${TARGETPLATFORM} = "linux/amd64" ]; then echo "x86_64"; elif [ ${TARGETPLATFORM} = "linux/arm64" ]; then echo "aarch64"; else echo "Unknown platform" && exit 1; fi;) \
+ && wget --quiet https://github.com/open-space-collective/open-space-toolkit-core/releases/download/${LATEST_PATCH_OF_MINOR}/open-space-toolkit-core-${LATEST_PATCH_OF_MINOR}-1.${PACKAGE_PLATFORM}-runtime.deb \
+ && wget --quiet https://github.com/open-space-collective/open-space-toolkit-core/releases/download/${LATEST_PATCH_OF_MINOR}/open-space-toolkit-core-${LATEST_PATCH_OF_MINOR}-1.${PACKAGE_PLATFORM}-devel.deb \
  && apt-get install -y ./*.deb \
  && rm -rf /tmp/open-space-toolkit-core
 


### PR DESCRIPTION
- Update stacktrace definitions to include platform-specific paths for x86_64 and aarch64
- Update Open Space Toolkit Core version to 2.2.x
- Update platform value in Makefile based on the PLATFORM variable
- Update platform value in CMake scripts based on the processor architecture
- Update requirements for open-space-toolkit-core to version 2.2.0 in Python bindings
- Add platform name to setup.cfg in Python tools
- Update base image in Dockerfile for development to openspacecollective/open-space-toolkit-base-development:latest
- Update Open Space Toolkit Core version to 2.2 in Dockerfile arguments

Requires ostk-core 3.0.0 release before passing, needs to be released as ostk-mathematics 3.0.0