### PR TITLE
feat: add norm tolerance on Quaternion isUnitary

### DIFF
--- a/bindings/python/src/OpenSpaceToolkitMathematicsPy/Geometry/3D/Transformation/Rotation/Quaternion.cpp
+++ b/bindings/python/src/OpenSpaceToolkitMathematicsPy/Geometry/3D/Transformation/Rotation/Quaternion.cpp
@@ -70,7 +70,7 @@ inline void OpenSpaceToolkitMathematicsPy_Geometry_3D_Transformation_Rotation_Qu
         )
 
         .def("is_defined", &Quaternion::isDefined)
-        .def("is_unitary", &Quaternion::isUnitary, arg("norm_tolerance") = Real::Epsilon())
+        .def("is_unitary", &Quaternion::isUnitary, arg_v("norm_tolerance", Real::Epsilon(), "Real.Epislon()"))
         .def("is_near", &Quaternion::isNear, arg("quaternion"), arg("angular_tolerance"))
 
         .def("x", &Quaternion::x)
@@ -89,7 +89,7 @@ inline void OpenSpaceToolkitMathematicsPy_Geometry_3D_Transformation_Rotation_Qu
         .def("cross_multiply", &Quaternion::crossMultiply, arg("quaternion"))
         .def("dot_multiply", &Quaternion::dotMultiply, arg("quaternion"))
         .def("dot_product", &Quaternion::dotProduct, arg("quaternion"))
-        .def("rotate_vector", &Quaternion::rotateVector, arg("vector"), arg("norm_tolerance") = Real::Epsilon())
+        .def("rotate_vector", &Quaternion::rotateVector, arg("vector"), arg_v("norm_tolerance", Real::Epsilon(), "Real.Epsilon()"))
         .def("to_vector", &Quaternion::toVector, arg("format"))
         .def(
             "to_string",

--- a/bindings/python/src/OpenSpaceToolkitMathematicsPy/Geometry/3D/Transformation/Rotation/Quaternion.cpp
+++ b/bindings/python/src/OpenSpaceToolkitMathematicsPy/Geometry/3D/Transformation/Rotation/Quaternion.cpp
@@ -70,7 +70,7 @@ inline void OpenSpaceToolkitMathematicsPy_Geometry_3D_Transformation_Rotation_Qu
         )
 
         .def("is_defined", &Quaternion::isDefined)
-        .def("is_unitary", &Quaternion::isUnitary)
+        .def("is_unitary", &Quaternion::isUnitary, arg("norm_tolerance"))
         .def("is_near", &Quaternion::isNear, arg("quaternion"), arg("angular_tolerance"))
 
         .def("x", &Quaternion::x)
@@ -89,7 +89,7 @@ inline void OpenSpaceToolkitMathematicsPy_Geometry_3D_Transformation_Rotation_Qu
         .def("cross_multiply", &Quaternion::crossMultiply, arg("quaternion"))
         .def("dot_multiply", &Quaternion::dotMultiply, arg("quaternion"))
         .def("dot_product", &Quaternion::dotProduct, arg("quaternion"))
-        .def("rotate_vector", &Quaternion::rotateVector, arg("vector"))
+        .def("rotate_vector", &Quaternion::rotateVector, arg("vector"), arg("norm_tolerance"))
         .def("to_vector", &Quaternion::toVector, arg("format"))
         .def(
             "to_string",

--- a/bindings/python/src/OpenSpaceToolkitMathematicsPy/Geometry/3D/Transformation/Rotation/Quaternion.cpp
+++ b/bindings/python/src/OpenSpaceToolkitMathematicsPy/Geometry/3D/Transformation/Rotation/Quaternion.cpp
@@ -71,7 +71,7 @@ inline void OpenSpaceToolkitMathematicsPy_Geometry_3D_Transformation_Rotation_Qu
 
         .def("is_defined", &Quaternion::isDefined)
         .def("is_unitary", &Quaternion::isUnitary, arg("norm_tolerance"))
-        .def("is_near", &Quaternion::isNear, arg("quaternion"), arg("angular_tolerance"))
+        .def("is_near", &Quaternion::isNear, arg("quaternion"), arg("angular_tolerance") = Real::Epsilon()))
 
         .def("x", &Quaternion::x)
         .def("y", &Quaternion::y)
@@ -89,7 +89,7 @@ inline void OpenSpaceToolkitMathematicsPy_Geometry_3D_Transformation_Rotation_Qu
         .def("cross_multiply", &Quaternion::crossMultiply, arg("quaternion"))
         .def("dot_multiply", &Quaternion::dotMultiply, arg("quaternion"))
         .def("dot_product", &Quaternion::dotProduct, arg("quaternion"))
-        .def("rotate_vector", &Quaternion::rotateVector, arg("vector"), arg("norm_tolerance"))
+        .def("rotate_vector", &Quaternion::rotateVector, arg("vector"), arg("norm_tolerance") = Real::Epsilon()))
         .def("to_vector", &Quaternion::toVector, arg("format"))
         .def(
             "to_string",

--- a/bindings/python/src/OpenSpaceToolkitMathematicsPy/Geometry/3D/Transformation/Rotation/Quaternion.cpp
+++ b/bindings/python/src/OpenSpaceToolkitMathematicsPy/Geometry/3D/Transformation/Rotation/Quaternion.cpp
@@ -70,8 +70,8 @@ inline void OpenSpaceToolkitMathematicsPy_Geometry_3D_Transformation_Rotation_Qu
         )
 
         .def("is_defined", &Quaternion::isDefined)
-        .def("is_unitary", &Quaternion::isUnitary, arg("norm_tolerance"))
-        .def("is_near", &Quaternion::isNear, arg("quaternion"), arg("angular_tolerance") = Real::Epsilon()))
+        .def("is_unitary", &Quaternion::isUnitary, arg("norm_tolerance") = Real::Epsilon())
+        .def("is_near", &Quaternion::isNear, arg("quaternion"), arg("angular_tolerance"))
 
         .def("x", &Quaternion::x)
         .def("y", &Quaternion::y)
@@ -89,7 +89,7 @@ inline void OpenSpaceToolkitMathematicsPy_Geometry_3D_Transformation_Rotation_Qu
         .def("cross_multiply", &Quaternion::crossMultiply, arg("quaternion"))
         .def("dot_multiply", &Quaternion::dotMultiply, arg("quaternion"))
         .def("dot_product", &Quaternion::dotProduct, arg("quaternion"))
-        .def("rotate_vector", &Quaternion::rotateVector, arg("vector"), arg("norm_tolerance") = Real::Epsilon()))
+        .def("rotate_vector", &Quaternion::rotateVector, arg("vector"), arg("norm_tolerance") = Real::Epsilon())
         .def("to_vector", &Quaternion::toVector, arg("format"))
         .def(
             "to_string",

--- a/bindings/python/test/geometry/d3/transformation/rotation/test_quaternion.py
+++ b/bindings/python/test/geometry/d3/transformation/rotation/test_quaternion.py
@@ -46,6 +46,7 @@ class TestQuaternion:
 
     def test_is_unitary_success(self, quaternion: Quaternion):
         assert quaternion.is_unitary() is True
+        assert quaternion.is_unitary(0.0001) is True
 
     def test_is_near_success(self, quaternion: Quaternion):
         assert quaternion.is_near(quaternion, Angle.zero()) is True

--- a/include/OpenSpaceToolkit/Mathematics/Geometry/3D/Transformation/Rotation/Quaternion.hpp
+++ b/include/OpenSpaceToolkit/Mathematics/Geometry/3D/Transformation/Rotation/Quaternion.hpp
@@ -275,7 +275,7 @@ class Quaternion
     ///
     /// @return                 True if Quaternion is unitary
 
-    bool isUnitary() const;
+    bool isUnitary(const Real& aNormTolerance = Real::Epsilon()) const;
 
     /// @brief                  Check if Quaternion is near another Quaternion
     ///
@@ -476,7 +476,7 @@ class Quaternion
     /// @param                  [in] aQuaternion A Quaternion
     /// @return                 Vector
 
-    Vector3d rotateVector(const Vector3d& aVector) const;
+    Vector3d rotateVector(const Vector3d& aVector, const Real& aNormTolerance = Real::Epsilon()) const;
 
     /// @brief                  Convert Quaternion to its vector representation
     ///

--- a/src/OpenSpaceToolkit/Mathematics/Geometry/3D/Transformation/Rotation/Quaternion.cpp
+++ b/src/OpenSpaceToolkit/Mathematics/Geometry/3D/Transformation/Rotation/Quaternion.cpp
@@ -173,12 +173,11 @@ bool Quaternion::isUnitary(const Real& aNormTolerance) const
         throw ostk::core::error::runtime::Undefined("Quaternion");
     }
 
-+    if (!aNormTolerance.isDefined() || aNormTolerance < 0.0)
-+    {
-+        throw ostk::core::error::runtime::Undefined("Norm tolerance");
-+    }
-+
-     return std::abs(((x_ * x_) + (y_ * y_) + (z_ * z_) + (s_ * s_)) - 1.0) <= aNormTolerance;
+    if (!aNormTolerance.isDefined() || aNormTolerance <= 0.0)
+    {
+        throw ostk::core::error::runtime::Undefined("Norm tolerance");
+    }
+
     return std::abs(((x_ * x_) + (y_ * y_) + (z_ * z_) + (s_ * s_)) - 1.0) <= aNormTolerance;
 }
 

--- a/src/OpenSpaceToolkit/Mathematics/Geometry/3D/Transformation/Rotation/Quaternion.cpp
+++ b/src/OpenSpaceToolkit/Mathematics/Geometry/3D/Transformation/Rotation/Quaternion.cpp
@@ -166,14 +166,14 @@ bool Quaternion::isDefined() const
     return x_.isDefined() && y_.isDefined() && z_.isDefined() && s_.isDefined();
 }
 
-bool Quaternion::isUnitary() const
+bool Quaternion::isUnitary(const Real& aNormTolerance) const
 {
     if (!this->isDefined())
     {
         throw ostk::core::error::runtime::Undefined("Quaternion");
     }
 
-    return std::abs(((x_ * x_) + (y_ * y_) + (z_ * z_) + (s_ * s_)) - 1.0) <= Real::Epsilon();
+    return std::abs(((x_ * x_) + (y_ * y_) + (z_ * z_) + (s_ * s_)) - 1.0) <= aNormTolerance;
 }
 
 bool Quaternion::isNear(const Quaternion& aQuaternion, const Angle& anAngularTolerance) const
@@ -349,14 +349,14 @@ Real Quaternion::dotProduct(const Quaternion& aQuaternion) const
     return (x_ * aQuaternion.x_) + (y_ * aQuaternion.y_) + (z_ * aQuaternion.z_) + (s_ * aQuaternion.s_);
 }
 
-Vector3d Quaternion::rotateVector(const Vector3d& aVector) const
+Vector3d Quaternion::rotateVector(const Vector3d& aVector, const Real& aNormTolerance) const
 {
     if (!aVector.isDefined())
     {
         throw ostk::core::error::runtime::Undefined("Vector");
     }
 
-    if (!this->isUnitary())
+    if (!this->isUnitary(aNormTolerance))
     {
         throw ostk::core::error::RuntimeError("Quaternion with norm [{}] is not unitary.", this->norm());
     }

--- a/src/OpenSpaceToolkit/Mathematics/Geometry/3D/Transformation/Rotation/Quaternion.cpp
+++ b/src/OpenSpaceToolkit/Mathematics/Geometry/3D/Transformation/Rotation/Quaternion.cpp
@@ -173,6 +173,12 @@ bool Quaternion::isUnitary(const Real& aNormTolerance) const
         throw ostk::core::error::runtime::Undefined("Quaternion");
     }
 
++    if (!aNormTolerance.isDefined() || aNormTolerance < 0.0)
++    {
++        throw ostk::core::error::runtime::Undefined("Norm tolerance");
++    }
++
+     return std::abs(((x_ * x_) + (y_ * y_) + (z_ * z_) + (s_ * s_)) - 1.0) <= aNormTolerance;
     return std::abs(((x_ * x_) + (y_ * y_) + (z_ * z_) + (s_ * s_)) - 1.0) <= aNormTolerance;
 }
 

--- a/test/OpenSpaceToolkit/Mathematics/Geometry/3D/Transformations/Rotations/Quaternion.test.cpp
+++ b/test/OpenSpaceToolkit/Mathematics/Geometry/3D/Transformations/Rotations/Quaternion.test.cpp
@@ -359,6 +359,7 @@ TEST(OpenSpaceToolkit_Mathematics_Geometry_3D_Transformation_Rotation_Quaternion
     {
         EXPECT_ANY_THROW(Quaternion::Undefined().isUnitary());
         EXPECT_ANY_THROW(Quaternion::Undefined().isUnitary(Real(0.0001)));
+        EXPECT_ANY_THROW(Quaternion::XYZS(1.0001, 0.0, 0.0, 0.0).isUnitary(Real(-0.0001)));
     }
 }
 

--- a/test/OpenSpaceToolkit/Mathematics/Geometry/3D/Transformations/Rotations/Quaternion.test.cpp
+++ b/test/OpenSpaceToolkit/Mathematics/Geometry/3D/Transformations/Rotations/Quaternion.test.cpp
@@ -352,7 +352,13 @@ TEST(OpenSpaceToolkit_Mathematics_Geometry_3D_Transformation_Rotation_Quaternion
     }
 
     {
+        EXPECT_FALSE(Quaternion::XYZS(1.0001, 0.0, 0.0, 0.0).isUnitary(Real(0.0001)));
+        EXPECT_TRUE(Quaternion::XYZS(1.0001, 0.0, 0.0, 0.0).isUnitary(Real(0.0003)));
+    }
+
+    {
         EXPECT_ANY_THROW(Quaternion::Undefined().isUnitary());
+        EXPECT_ANY_THROW(Quaternion::Undefined().isUnitary(Real(0.0001)));
     }
 }
 


### PR DESCRIPTION
- This is retro-compatible. 
- Need this to be used with physical measured values where Real::Epsilon() is sometimes too much to ask

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced `Quaternion` class with a new `norm_tolerance` parameter for `is_unitary` and `rotate_vector` methods, allowing for customizable precision in operations.
  
- **Bug Fixes**
	- Improved error handling for `is_unitary` to ensure exceptions are thrown for undefined quaternions.

- **Tests**
	- Added new test cases for `is_unitary` method with tolerance checks to ensure robust validation of quaternion operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->