### PR TITLE
docs: add docs for ostk.mathematics.geometry.d3.transformation.rotation

### DIFF
--- a/docs/python.rst
+++ b/docs/python.rst
@@ -11,9 +11,9 @@ Python API Documentation
    ostk.mathematics.curve_fitting.interpolator
    ostk.mathematics.geometry
    ostk.mathematics.geometry.d2
-   ostk.mathematics.geometry.d2.object 
+   ostk.mathematics.geometry.d2.object
    ostk.mathematics.geometry.d3
    ostk.mathematics.geometry.d3.object
-   ostk.mathematics.geometry.d3.transformation
+   ostk.mathematics.geometry.d3.transformation.rotation
    ostk.mathematics.object
    ostk.mathematics.solver


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated Python API documentation to provide more precise module references
  - Refined reference to 3D geometry transformation, specifically highlighting rotation submodule

<!-- end of auto-generated comment: release notes by coderabbit.ai -->