### PR TITLE
fix: remove py.typed, fix other mypy issues

### DIFF
--- a/bindings/python/CMakeLists.txt
+++ b/bindings/python/CMakeLists.txt
@@ -156,7 +156,6 @@ FUNCTION (PY_ADD_PACKAGE_DIRECTORY NAME)
                             COMMAND cp "${CMAKE_SOURCE_DIR}/lib/${LIBRARY_TARGET}.*${EXTENSION}*.so" "${CMAKE_CURRENT_BINARY_DIR}/${NAME}/${PROJECT_PATH}/"
                             COMMAND cp "${CMAKE_CURRENT_SOURCE_DIR}/requirements.txt" "${CMAKE_CURRENT_BINARY_DIR}/${NAME}/requirements.txt"
                             COMMAND cp "${CMAKE_CURRENT_SOURCE_DIR}/README.md" "${CMAKE_CURRENT_BINARY_DIR}/${NAME}/README.md"
-                            COMMAND cp "${CMAKE_CURRENT_SOURCE_DIR}/py.typed" "${CMAKE_CURRENT_BINARY_DIR}/${NAME}/${PROJECT_PATH}/py.typed"
                             COMMAND cd "${CMAKE_CURRENT_BINARY_DIR}/${NAME}" && python${PYTHON_VERSION} -m pip install .
                             COMMAND python${PYTHON_VERSION} -m "pybind11_stubgen" -o "${CMAKE_CURRENT_BINARY_DIR}/${NAME}" "${PROJECT_GROUP}.${PROJECT_SUBGROUP}" # generate stubs in same dir as binaries
                             COMMAND find "${CMAKE_CURRENT_BINARY_DIR}/${NAME}/${PROJECT_GROUP}" -type f -name "*.pyi" -exec sed -i "s/: \\\\.\\\\.\\\\./: typing.Any/g" {} + # crudely fix stubs with invalid syntax

--- a/bindings/python/test/geometry/d2/conftest.py
+++ b/bindings/python/test/geometry/d2/conftest.py
@@ -4,15 +4,12 @@ import pytest
 
 import numpy as np
 
-import ostk.mathematics as mathematics
-
-
-Point = mathematics.geometry.d2.object.Point
-PointSet = mathematics.geometry.d2.object.PointSet
-Line = mathematics.geometry.d2.object.Line
-Segment = mathematics.geometry.d2.object.Segment
-Polygon = mathematics.geometry.d2.object.Polygon
-Composite = mathematics.geometry.d2.object.Composite
+from ostk.mathematics.geometry.d2.object import Point
+from ostk.mathematics.geometry.d2.object import PointSet
+from ostk.mathematics.geometry.d2.object import Line
+from ostk.mathematics.geometry.d2.object import Segment
+from ostk.mathematics.geometry.d2.object import Polygon
+from ostk.mathematics.geometry.d2.object import Composite
 
 
 @pytest.fixture

--- a/bindings/python/test/geometry/d2/object/test_composite.py
+++ b/bindings/python/test/geometry/d2/object/test_composite.py
@@ -2,13 +2,10 @@
 
 import pytest
 
-import ostk.mathematics as mathematics
-
-
-Object = mathematics.geometry.d2.Object
-Point = mathematics.geometry.d2.object.Point
-Polygon = mathematics.geometry.d2.object.Polygon
-Composite = mathematics.geometry.d2.object.Composite
+from ostk.mathematics.geometry.d2 import Object
+from ostk.mathematics.geometry.d2.object import Point
+from ostk.mathematics.geometry.d2.object import Polygon
+from ostk.mathematics.geometry.d2.object import Composite
 
 
 class TestComposite:

--- a/bindings/python/test/geometry/d2/object/test_multipolygon.py
+++ b/bindings/python/test/geometry/d2/object/test_multipolygon.py
@@ -1,17 +1,10 @@
 # Apache License 2.0
 
-import pytest
-
 import numpy as np
 
-import ostk.mathematics as mathematics
-
-from ostk.core.type import String
-
-
-Object = mathematics.geometry.d2.Object
-Polygon = mathematics.geometry.d2.object.Polygon
-MultiPolygon = mathematics.geometry.d2.object.MultiPolygon
+from ostk.mathematics.geometry.d2 import Object
+from ostk.mathematics.geometry.d2.object import Polygon
+from ostk.mathematics.geometry.d2.object import MultiPolygon
 
 
 class TestMultipolygon:

--- a/bindings/python/test/geometry/d2/object/test_point_set.py
+++ b/bindings/python/test/geometry/d2/object/test_point_set.py
@@ -2,12 +2,9 @@
 
 from collections.abc import Iterator, Iterable
 
-import ostk.mathematics as mathematics
-
-
-Object = mathematics.geometry.d2.Object
-Point = mathematics.geometry.d2.object.Point
-PointSet = mathematics.geometry.d2.object.PointSet
+from ostk.mathematics.geometry.d2 import Object
+from ostk.mathematics.geometry.d2.object import Point
+from ostk.mathematics.geometry.d2.object import PointSet
 
 
 class TestPointSet:

--- a/bindings/python/test/geometry/d3/object/test_point_set.py
+++ b/bindings/python/test/geometry/d3/object/test_point_set.py
@@ -4,13 +4,10 @@ from collections.abc import Iterator, Iterable
 
 import pytest
 
-import ostk.mathematics as mathematics
-
-
-Object = mathematics.geometry.d3.Object
-Point = mathematics.geometry.d3.object.Point
-PointSet = mathematics.geometry.d3.object.PointSet
-Transformation = mathematics.geometry.d3.Transformation
+from ostk.mathematics.geometry.d3 import Object
+from ostk.mathematics.geometry.d3 import Transformation
+from ostk.mathematics.geometry.d3.object import Point
+from ostk.mathematics.geometry.d3.object import PointSet
 
 
 @pytest.fixture
@@ -52,7 +49,7 @@ class TestPointSet:
         assert point_set.is_defined()
 
     def test_empty_success(self):
-        point_set: Pointset = PointSet.empty()
+        point_set: PointSet = PointSet.empty()
 
         assert point_set is not None
         assert isinstance(point_set, PointSet)

--- a/bindings/python/test/solver/test_numerical_solver.py
+++ b/bindings/python/test/solver/test_numerical_solver.py
@@ -133,7 +133,7 @@ class TestNumericalSolver:
         assert 5e-9 >= abs(state_vector[0] - math.sin(integration_duration))
         assert 5e-9 >= abs(state_vector[1] - math.cos(integration_duration))
 
-        integration_durations = np.arange(100.0, 200.0, 50.0)
+        integration_durations = np.arange(100.0, 200.0, 50.0).astype(float)
         solutions = numerical_solver.integrate_duration(
             initial_state_vec, integration_durations, oscillator
         )
@@ -157,7 +157,7 @@ class TestNumericalSolver:
         assert 5e-9 >= abs(state_vector[0] - math.sin(end_time))
         assert 5e-9 >= abs(state_vector[1] - math.cos(end_time))
 
-        end_times = np.arange(600.0, 700.0, 50.0)
+        end_times = np.arange(600.0, 700.0, 50.0).astype(float)
         solutions = numerical_solver.integrate_time(
             initial_state_vec, start_time, end_times, oscillator
         )


### PR DESCRIPTION
See https://github.com/open-space-collective/open-space-toolkit-core/pull/186 for justification on removing `py.typed` for now. 

Additionally, removes the type aliasing pattern used in the Python tests because these are [incompatible with mypy](https://mypy.readthedocs.io/en/stable/common_issues.html#variables-vs-type-aliases)