### PR TITLE
build: loosen boost version req to 1.82

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -241,7 +241,7 @@ ENDFOREACH ()
 
 ## Dependencies
 
-### Boost [1.87.0]
+### Boost [1.82.0]
 
 IF (BUILD_WITH_BOOST_STATIC)
     SET (Boost_USE_STATIC_LIBS ON)
@@ -251,7 +251,7 @@ ENDIF ()
 
 SET (Boost_USE_MULTITHREADED ON)
 
-FIND_PACKAGE ("Boost" "1.87")
+FIND_PACKAGE ("Boost" "1.82")
 
 IF (BUILD_WITH_BOOST_STACKTRACE)
     ## Stacktrace definitions


### PR DESCRIPTION
See https://github.com/open-space-collective/open-space-toolkit-core/pull/187

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated Boost library dependency version from 1.87.0 to 1.82.0

<!-- end of auto-generated comment: release notes by coderabbit.ai -->