### PR TITLE
feat: add prime computation for interpolators

### DIFF
--- a/bindings/python/src/OpenSpaceToolkitMathematicsPy/CurveFitting/Interpolator.cpp
+++ b/bindings/python/src/OpenSpaceToolkitMathematicsPy/CurveFitting/Interpolator.cpp
@@ -30,6 +30,16 @@ class PyInterpolator : public Interpolator
     {
         PYBIND11_OVERRIDE_PURE(double, Interpolator, evaluate, aQueryValue);
     }
+
+    double computeDerivative(const double& aQueryValue) const override
+    {
+        PYBIND11_OVERRIDE_PURE(double, Interpolator, computeDerivative, aQueryValue);
+    }
+
+    VectorXd computeDerivative(const VectorXd& aQueryVector) const override
+    {
+        PYBIND11_OVERRIDE_PURE(VectorXd, Interpolator, computeDerivative, aQueryVector);
+    }
 };
 
 inline void OpenSpaceToolkitMathematicsPy_CurveFitting_Interpolator(pybind11::module& aModule)
@@ -52,6 +62,8 @@ inline void OpenSpaceToolkitMathematicsPy_CurveFitting_Interpolator(pybind11::mo
 
         .def("evaluate", overload_cast<const VectorXd&>(&Interpolator::evaluate, const_), arg("x"))
         .def("evaluate", overload_cast<const double&>(&Interpolator::evaluate, const_), arg("x"))
+        .def("compute_derivative", overload_cast<const double&>(&Interpolator::computeDerivative, const_), arg("x"))
+        .def("compute_derivative", overload_cast<const VectorXd&>(&Interpolator::computeDerivative, const_), arg("x"))
 
         .def_static(
             "generate_interpolator", &Interpolator::GenerateInterpolator, arg("interpolation_type"), arg("x"), arg("y")

--- a/bindings/python/src/OpenSpaceToolkitMathematicsPy/CurveFitting/Interpolator/BarycentricRational.cpp
+++ b/bindings/python/src/OpenSpaceToolkitMathematicsPy/CurveFitting/Interpolator/BarycentricRational.cpp
@@ -18,5 +18,17 @@ inline void OpenSpaceToolkitMathematicsPy_CurveFitting_Interpolator_BarycentricR
         .def(init<const VectorXd&, const VectorXd&>(), arg("x"), arg("y"))
 
         .def("evaluate", overload_cast<const VectorXd&>(&BarycentricRational::evaluate, const_), arg("x"))
-        .def("evaluate", overload_cast<const double&>(&BarycentricRational::evaluate, const_), arg("x"));
+        .def("evaluate", overload_cast<const double&>(&BarycentricRational::evaluate, const_), arg("x"))
+        .def(
+            "compute_derivative",
+            overload_cast<const double&>(&BarycentricRational::computeDerivative, const_),
+            arg("x")
+        )
+        .def(
+            "compute_derivative",
+            overload_cast<const VectorXd&>(&BarycentricRational::computeDerivative, const_),
+            arg("x")
+        )
+
+        ;
 }

--- a/bindings/python/src/OpenSpaceToolkitMathematicsPy/CurveFitting/Interpolator/CubicSpline.cpp
+++ b/bindings/python/src/OpenSpaceToolkitMathematicsPy/CurveFitting/Interpolator/CubicSpline.cpp
@@ -20,5 +20,9 @@ inline void OpenSpaceToolkitMathematicsPy_CurveFitting_Interpolator_CubicSpline(
         .def(init<const VectorXd&, const Real&, const Real&>(), arg("y"), arg("x_0"), arg("h"))
 
         .def("evaluate", overload_cast<const VectorXd&>(&CubicSpline::evaluate, const_), arg("x"))
-        .def("evaluate", overload_cast<const double&>(&CubicSpline::evaluate, const_), arg("x"));
+        .def("evaluate", overload_cast<const double&>(&CubicSpline::evaluate, const_), arg("x"))
+        .def("compute_derivative", overload_cast<const double&>(&CubicSpline::computeDerivative, const_), arg("x"))
+        .def("compute_derivative", overload_cast<const VectorXd&>(&CubicSpline::computeDerivative, const_), arg("x"))
+
+        ;
 }

--- a/bindings/python/src/OpenSpaceToolkitMathematicsPy/CurveFitting/Interpolator/Linear.cpp
+++ b/bindings/python/src/OpenSpaceToolkitMathematicsPy/CurveFitting/Interpolator/Linear.cpp
@@ -18,5 +18,9 @@ inline void OpenSpaceToolkitMathematicsPy_CurveFitting_Interpolator_Linear(pybin
         .def(init<const VectorXd&, const VectorXd&>(), arg("x"), arg("y"))
 
         .def("evaluate", overload_cast<const VectorXd&>(&Linear::evaluate, const_), arg("x"))
-        .def("evaluate", overload_cast<const double&>(&Linear::evaluate, const_), arg("x"));
+        .def("evaluate", overload_cast<const double&>(&Linear::evaluate, const_), arg("x"))
+        .def("compute_derivative", overload_cast<const double&>(&Linear::computeDerivative, const_), arg("x"))
+        .def("compute_derivative", overload_cast<const VectorXd&>(&Linear::computeDerivative, const_), arg("x"))
+
+        ;
 }

--- a/bindings/python/test/curve_fitting/interpolator/test_barycentric_rational.py
+++ b/bindings/python/test/curve_fitting/interpolator/test_barycentric_rational.py
@@ -35,14 +35,10 @@ class TestBarycentricRational:
 
     def test_compute_derivative(self):
         interpolator = BarycentricRational(
-            x=[0.0, 1.0, 2.0, 4.0, 5.0, 6.0], y=[0.0, 3.0, 6.0, 9.0, 17.0, 5.0]
+            x=[0.0, 1.0, 2.0, 4.0, 5.0, 6.0],
+            y=[0.0, 3.0, 6.0, 9.0, 17.0, 5.0],
         )
 
         assert interpolator.compute_derivative(1.5) is not None
-
-    def test_compute_derivative(self):
-        interpolator = BarycentricRational(
-            x=[0.0, 1.0, 2.0, 4.0, 5.0, 6.0], y=[0.0, 3.0, 6.0, 9.0, 17.0, 5.0]
-        )
 
         assert interpolator.compute_derivative([1.5]) is not None

--- a/bindings/python/test/curve_fitting/interpolator/test_barycentric_rational.py
+++ b/bindings/python/test/curve_fitting/interpolator/test_barycentric_rational.py
@@ -32,3 +32,17 @@ class TestBarycentricRational:
             interpolator.evaluate(x=[0.0, 1.0, 2.0, 4.0, 5.0, 6.0])
             == [0.0, 3.0, 6.0, 9.0, 17.0, 5.0]
         ).all()
+
+    def test_compute_derivative(self):
+        interpolator = BarycentricRational(
+            x=[0.0, 1.0, 2.0, 4.0, 5.0, 6.0], y=[0.0, 3.0, 6.0, 9.0, 17.0, 5.0]
+        )
+
+        assert interpolator.compute_derivative(1.5) is not None
+
+    def test_compute_derivative(self):
+        interpolator = BarycentricRational(
+            x=[0.0, 1.0, 2.0, 4.0, 5.0, 6.0], y=[0.0, 3.0, 6.0, 9.0, 17.0, 5.0]
+        )
+
+        assert interpolator.compute_derivative([1.5]) is not None

--- a/bindings/python/test/curve_fitting/interpolator/test_cubic_spline.py
+++ b/bindings/python/test/curve_fitting/interpolator/test_cubic_spline.py
@@ -43,3 +43,17 @@ class TestCubicSpline:
             assert pytest.approx(interpolator.evaluate(i * 10.0)) == y[i]
 
         assert pytest.approx(interpolator.evaluate(np.linspace(0.0, 90.0, 10))) == y
+
+    def test_compute_derivative(self):
+        interpolator = CubicSpline(
+            x=[0.0, 1.0, 2.0, 3.0, 4.0, 5.0], y=[0.0, 3.0, 6.0, 9.0, 17.0, 5.0]
+        )
+
+        assert interpolator.compute_derivative(1.5) is not None
+
+    def test_compute_derivative(self):
+        interpolator = CubicSpline(
+            x=[0.0, 1.0, 2.0, 3.0, 4.0, 5.0], y=[0.0, 3.0, 6.0, 9.0, 17.0, 5.0]
+        )
+
+        assert interpolator.compute_derivative([1.5]) is not None

--- a/bindings/python/test/curve_fitting/interpolator/test_cubic_spline.py
+++ b/bindings/python/test/curve_fitting/interpolator/test_cubic_spline.py
@@ -46,14 +46,10 @@ class TestCubicSpline:
 
     def test_compute_derivative(self):
         interpolator = CubicSpline(
-            x=[0.0, 1.0, 2.0, 3.0, 4.0, 5.0], y=[0.0, 3.0, 6.0, 9.0, 17.0, 5.0]
+            x=[0.0, 1.0, 2.0, 3.0, 4.0, 5.0],
+            y=[0.0, 3.0, 6.0, 9.0, 17.0, 5.0],
         )
 
         assert interpolator.compute_derivative(1.5) is not None
-
-    def test_compute_derivative(self):
-        interpolator = CubicSpline(
-            x=[0.0, 1.0, 2.0, 3.0, 4.0, 5.0], y=[0.0, 3.0, 6.0, 9.0, 17.0, 5.0]
-        )
 
         assert interpolator.compute_derivative([1.5]) is not None

--- a/bindings/python/test/curve_fitting/interpolator/test_linear.py
+++ b/bindings/python/test/curve_fitting/interpolator/test_linear.py
@@ -36,14 +36,10 @@ class TestLinear:
 
     def test_compute_derivative(self):
         interpolator = Linear(
-            x=[0.0, 1.0, 2.0, 4.0, 5.0, 6.0], y=[0.0, 3.0, 6.0, 9.0, 17.0, 5.0]
+            x=[0.0, 1.0, 2.0, 4.0, 5.0, 6.0],
+            y=[0.0, 3.0, 6.0, 9.0, 17.0, 5.0],
         )
 
         assert interpolator.compute_derivative(1.5) is not None
-
-    def test_compute_derivative(self):
-        interpolator = Linear(
-            x=[0.0, 1.0, 2.0, 4.0, 5.0, 6.0], y=[0.0, 3.0, 6.0, 9.0, 17.0, 5.0]
-        )
 
         assert interpolator.compute_derivative([1.5]) is not None

--- a/bindings/python/test/curve_fitting/interpolator/test_linear.py
+++ b/bindings/python/test/curve_fitting/interpolator/test_linear.py
@@ -33,3 +33,17 @@ class TestLinear:
             interpolator.evaluate(x=[0.0, 1.0, 2.0, 4.0, 5.0, 6.0])
             == [0.0, 3.0, 6.0, 9.0, 17.0, 5.0]
         ).all()
+
+    def test_compute_derivative(self):
+        interpolator = Linear(
+            x=[0.0, 1.0, 2.0, 4.0, 5.0, 6.0], y=[0.0, 3.0, 6.0, 9.0, 17.0, 5.0]
+        )
+
+        assert interpolator.compute_derivative(1.5) is not None
+
+    def test_compute_derivative(self):
+        interpolator = Linear(
+            x=[0.0, 1.0, 2.0, 4.0, 5.0, 6.0], y=[0.0, 3.0, 6.0, 9.0, 17.0, 5.0]
+        )
+
+        assert interpolator.compute_derivative([1.5]) is not None

--- a/include/OpenSpaceToolkit/Mathematics/CurveFitting/Interpolator.hpp
+++ b/include/OpenSpaceToolkit/Mathematics/CurveFitting/Interpolator.hpp
@@ -62,6 +62,18 @@ class Interpolator
     /// @return Vector of y values
     virtual double evaluate(const double& aQueryValue) const = 0;
 
+    /// @brief Get the derivative of the interpolator
+    ///
+    /// @param aQueryValue An x value
+    /// @return Derivative of the interpolator at the given x value
+    virtual double computeDerivative(const double& aQueryValue) const = 0;
+
+    /// @brief Get the derivative of the interpolator
+    ///
+    /// @param aQueryVector A vector of x values
+    /// @return Vector of derivatives of the interpolator at the given x values
+    virtual VectorXd computeDerivative(const VectorXd& aQueryVector) const = 0;
+
     /// @brief Generate an interpolator
     ///
     /// @param aType Interpolation type

--- a/include/OpenSpaceToolkit/Mathematics/CurveFitting/Interpolator/BarycentricRational.hpp
+++ b/include/OpenSpaceToolkit/Mathematics/CurveFitting/Interpolator/BarycentricRational.hpp
@@ -73,6 +73,26 @@ class BarycentricRational : public Interpolator
     /// @return Vector of y values
     virtual double evaluate(const double& aQueryValue) const override;
 
+    /// @brief Compute the derivative at a specific query value
+    /// @param aQueryValue The x value to compute the derivative at
+    ///
+    /// @code{.cpp}
+    ///                     double derivative = barycentricRational.computeDerivative(5.0) ;
+    /// @endcode
+    ///
+    /// @return The derivative at the given x value
+    virtual double computeDerivative(const double& aQueryValue) const override;
+
+    /// @brief Compute the derivatives at multiple query values
+    /// @param aQueryVector A vector of x values to compute the derivatives at
+    ///
+    /// @code{.cpp}
+    ///                     VectorXd derivatives = barycentricRational.computeDerivative({1.0, 5.0, 6.0}) ;
+    /// @endcode
+    ///
+    /// @return A vector of derivatives at the given x values
+    virtual VectorXd computeDerivative(const VectorXd& aQueryVector) const override;
+
    private:
     barycentric_rational<double> interpolator_;
 };

--- a/include/OpenSpaceToolkit/Mathematics/CurveFitting/Interpolator/CubicSpline.hpp
+++ b/include/OpenSpaceToolkit/Mathematics/CurveFitting/Interpolator/CubicSpline.hpp
@@ -90,6 +90,26 @@ class CubicSpline : public Interpolator
     /// @return Vector of y values
     virtual double evaluate(const double& aQueryValue) const override;
 
+    /// @brief Compute the derivative at a specific query value
+    /// @param aQueryValue The x value to compute the derivative at
+    ///
+    /// @code{.cpp}
+    ///                     double derivative = cubicSpline.computeDerivative(5.0) ;
+    /// @endcode
+    ///
+    /// @return The derivative at the given x value
+    virtual double computeDerivative(const double& aQueryValue) const override;
+
+    /// @brief Compute the derivatives at multiple query values
+    /// @param aQueryVector A vector of x values to compute the derivatives at
+    ///
+    /// @code{.cpp}
+    ///                     VectorXd derivatives = cubicSpline.computeDerivative({1.0, 5.0, 6.0}) ;
+    /// @endcode
+    ///
+    /// @return A vector of derivatives at the given x values
+    virtual VectorXd computeDerivative(const VectorXd& aQueryVector) const override;
+
    private:
     cardinal_cubic_b_spline<double> interpolator_;
 };

--- a/include/OpenSpaceToolkit/Mathematics/CurveFitting/Interpolator/Linear.hpp
+++ b/include/OpenSpaceToolkit/Mathematics/CurveFitting/Interpolator/Linear.hpp
@@ -75,6 +75,26 @@ class Linear : public Interpolator
     /// @return Vector of y values
     virtual double evaluate(const double& aQueryValue) const override;
 
+    /// @brief Get the derivative of the linear interpolator
+    ///
+    /// @code{.cpp}
+    ///                     double derivative = linear.computeDerivative(5.0) ;
+    /// @endcode
+    ///
+    /// @param aQueryValue An x value
+    /// @return Derivative of the interpolator at the given x value
+    virtual double computeDerivative(const double& aQueryValue) const override;
+
+    /// @brief Get the derivative of the linear interpolator
+    ///
+    /// @code{.cpp}
+    ///                     VectorXd derivatives = linear.computeDerivative({1.0, 5.0, 6.0}) ;
+    /// @endcode
+    ///
+    /// @param aQueryVector A vector of x values
+    /// @return Vector of derivatives of the interpolator at the given x values
+    virtual VectorXd computeDerivative(const VectorXd& aQueryVector) const override;
+
    private:
     VectorXd x_;
     VectorXd y_;

--- a/src/OpenSpaceToolkit/Mathematics/CurveFitting/Interpolator/BarycentricRational.cpp
+++ b/src/OpenSpaceToolkit/Mathematics/CurveFitting/Interpolator/BarycentricRational.cpp
@@ -42,6 +42,23 @@ double BarycentricRational::evaluate(const double& aQueryValue) const
     return interpolator_(aQueryValue);
 }
 
+double BarycentricRational::computeDerivative(const double& aQueryValue) const
+{
+    return interpolator_.prime(aQueryValue);
+}
+
+VectorXd BarycentricRational::computeDerivative(const VectorXd& aQueryVector) const
+{
+    VectorXd yOutput(aQueryVector.size());
+
+    for (int i = 0; i < aQueryVector.size(); ++i)
+    {
+        yOutput(i) = interpolator_.prime(aQueryVector(i));
+    }
+
+    return yOutput;
+}
+
 }  // namespace interpolator
 }  // namespace curvefitting
 }  // namespace mathematics

--- a/src/OpenSpaceToolkit/Mathematics/CurveFitting/Interpolator/CubicSpline.cpp
+++ b/src/OpenSpaceToolkit/Mathematics/CurveFitting/Interpolator/CubicSpline.cpp
@@ -70,6 +70,23 @@ double CubicSpline::evaluate(const double& aQueryValue) const
     return interpolator_(aQueryValue);
 }
 
+double CubicSpline::computeDerivative(const double& aQueryValue) const
+{
+    return interpolator_.prime(aQueryValue);
+}
+
+VectorXd CubicSpline::computeDerivative(const VectorXd& aQueryVector) const
+{
+    VectorXd yOutput(aQueryVector.size());
+
+    for (int i = 0; i < aQueryVector.size(); ++i)
+    {
+        yOutput(i) = interpolator_.prime(aQueryVector(i));
+    }
+
+    return yOutput;
+}
+
 }  // namespace interpolator
 }  // namespace curvefitting
 }  // namespace mathematics

--- a/src/OpenSpaceToolkit/Mathematics/CurveFitting/Interpolator/Linear.cpp
+++ b/src/OpenSpaceToolkit/Mathematics/CurveFitting/Interpolator/Linear.cpp
@@ -13,6 +13,8 @@ namespace curvefitting
 namespace interpolator
 {
 
+using ostk::core::container::Unpack;
+
 Linear::Linear(const VectorXd& anXVector, const VectorXd& aYVector)
     : Interpolator(Interpolator::Type::Linear),
       x_(anXVector),
@@ -63,6 +65,33 @@ double Linear::evaluate(const double& aQueryValue) const
     const Real Ratio = (aQueryValue - x_(previousIndex)) / (x_(nextIndex) - x_(previousIndex));
 
     return previousY + Ratio * (nextY - previousY);
+}
+
+double Linear::computeDerivative(const double& aQueryValue) const
+{
+    Index previousIndex;
+    Index nextIndex;
+
+    Unpack(previousIndex, nextIndex) = findIndexRange(aQueryValue);
+
+    if (previousIndex == nextIndex)
+    {
+        return 0.0;
+    }
+
+    return (y_(nextIndex) - y_(previousIndex)) / (x_(nextIndex) - x_(previousIndex));
+}
+
+VectorXd Linear::computeDerivative(const VectorXd& aQueryVector) const
+{
+    VectorXd yOutput(aQueryVector.size());
+
+    for (int i = 0; i < aQueryVector.size(); ++i)
+    {
+        yOutput(i) = computeDerivative(aQueryVector(i));
+    }
+
+    return yOutput;
 }
 
 Pair<Index, Index> Linear::findIndexRange(const double& aQueryValue) const

--- a/test/OpenSpaceToolkit/Mathematics/CurveFitting/Interpolator.test.cpp
+++ b/test/OpenSpaceToolkit/Mathematics/CurveFitting/Interpolator.test.cpp
@@ -26,6 +26,8 @@ class MockInterpolator : public Interpolator
 
     MOCK_METHOD(VectorXd, evaluate, (const VectorXd&), (const, override));
     MOCK_METHOD(double, evaluate, (const double&), (const, override));
+    MOCK_METHOD(double, computeDerivative, (const double&), (const, override));
+    MOCK_METHOD(VectorXd, computeDerivative, (const VectorXd&), (const, override));
 };
 
 class OpenSpaceToolkit_Mathematics_Interpolator : public ::testing::Test

--- a/test/OpenSpaceToolkit/Mathematics/CurveFitting/Interpolator/BarycentricRational.test.cpp
+++ b/test/OpenSpaceToolkit/Mathematics/CurveFitting/Interpolator/BarycentricRational.test.cpp
@@ -83,3 +83,39 @@ TEST(OpenSpaceToolkit_Mathematics_Interpolator_BarycentricRational, Evaluate)
         }
     }
 }
+
+TEST(OpenSpaceToolkit_Mathematics_Interpolator_BarycentricRational, ComputeDerivative)
+{
+    {
+        VectorXd x(6);
+        x << 0.0, 1.0, 2.0, 3.0, 4.0, 5.0;
+
+        VectorXd y(6);
+        y << 0.0, 3.0, 5.0, 6.0, 9.0, 15.0;
+
+        BarycentricRational interpolator(x, y);
+
+        // Values taken from scipy
+        EXPECT_NEAR(interpolator.computeDerivative(1.5), 1.9765624999999993, 1e-1);
+        EXPECT_NEAR(interpolator.computeDerivative(3.5), 2.9348958333333335, 1e-1);
+    }
+
+    {
+        VectorXd x(6);
+        x << 0.0, 1.0, 2.0, 3.0, 4.0, 5.0;
+
+        VectorXd y(6);
+        y << 0.0, 3.0, 5.0, 6.0, 9.0, 15.0;
+
+        BarycentricRational interpolator(x, y);
+
+        VectorXd query(2);
+        query << 1.5, 3.5;
+
+        VectorXd derivatives = interpolator.computeDerivative(query);
+
+        // Values taken from scipy
+        EXPECT_NEAR(derivatives(0), 1.9765624999999993, 1e-1);
+        EXPECT_NEAR(derivatives(1), 2.9348958333333335, 1e-1);
+    }
+}

--- a/test/OpenSpaceToolkit/Mathematics/CurveFitting/Interpolator/CubicSpline.test.cpp
+++ b/test/OpenSpaceToolkit/Mathematics/CurveFitting/Interpolator/CubicSpline.test.cpp
@@ -93,3 +93,39 @@ TEST(OpenSpaceToolkit_Mathematics_Interpolator_CubicSpline, Evaluate)
         }
     }
 }
+
+TEST(OpenSpaceToolkit_Mathematics_Interpolator_CubicSpline, ComputeDerivative)
+{
+    {
+        VectorXd x(6);
+        x << 0.0, 1.0, 2.0, 3.0, 4.0, 5.0;
+
+        VectorXd y(6);
+        y << 0.0, 3.0, 5.0, 6.0, 9.0, 15.0;
+
+        CubicSpline interpolator(x, y);
+
+        // Values taken from scipy
+        EXPECT_NEAR(interpolator.computeDerivative(1.5), 2.03888889, 1e-1);
+        EXPECT_NEAR(interpolator.computeDerivative(3.5), 2.98888889, 1e-1);
+    }
+
+    {
+        VectorXd x(6);
+        x << 0.0, 1.0, 2.0, 3.0, 4.0, 5.0;
+
+        VectorXd y(6);
+        y << 0.0, 3.0, 5.0, 6.0, 9.0, 15.0;
+
+        CubicSpline interpolator(x, y);
+
+        VectorXd query(2);
+        query << 1.5, 3.5;
+
+        VectorXd derivatives = interpolator.computeDerivative(query);
+
+        // Values taken from scipy
+        EXPECT_NEAR(derivatives(0), 2.03888889, 1e-1);
+        EXPECT_NEAR(derivatives(1), 2.98888889, 1e-1);
+    }
+}

--- a/test/OpenSpaceToolkit/Mathematics/CurveFitting/Interpolator/Linear.test.cpp
+++ b/test/OpenSpaceToolkit/Mathematics/CurveFitting/Interpolator/Linear.test.cpp
@@ -83,3 +83,38 @@ TEST(OpenSpaceToolkit_Mathematics_Interpolator_Linear, Evaluate)
         }
     }
 }
+
+TEST(OpenSpaceToolkit_Mathematics_Interpolator_Linear, ComputeDerivative)
+{
+    {
+        VectorXd x(6);
+        x << 0.0, 1.0, 2.0, 3.0, 4.0, 5.0;
+
+        VectorXd y(6);
+        y << 0.0, 3.0, 5.0, 6.0, 9.0, 15.0;
+
+        Linear interpolator(x, y);
+
+        EXPECT_NEAR(interpolator.computeDerivative(1.5), 2.0, 1e-6);
+        EXPECT_NEAR(interpolator.computeDerivative(3.5), 3.0, 1e-6);
+    }
+
+    {
+        VectorXd x(6);
+        x << 0.0, 1.0, 2.0, 3.0, 4.0, 5.0;
+
+        VectorXd y(6);
+        y << 0.0, 3.0, 5.0, 6.0, 9.0, 15.0;
+
+        Linear interpolator(x, y);
+
+        VectorXd query(3);
+        query << 1.5, 2.5, 3.5;
+
+        VectorXd derivatives = interpolator.computeDerivative(query);
+
+        EXPECT_NEAR(derivatives(0), 2.0, 1e-6);
+        EXPECT_NEAR(derivatives(1), 1.0, 1e-6);
+        EXPECT_NEAR(derivatives(2), 3.0, 1e-6);
+    }
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for computing derivatives of interpolated curves in Barycentric Rational, Cubic Spline, and Linear interpolators. Users can now obtain derivatives at single points or multiple points directly from both C++ and Python interfaces.

- **Tests**
  - Introduced new tests to verify the correctness of derivative computations for all supported interpolator types, ensuring reliable results for both scalar and vector inputs in both C++ and Python environments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->