### PR TITLE
fix: quaternion unitary check

### DIFF
--- a/src/OpenSpaceToolkit/Mathematics/Geometry/3D/Transformation/Rotation/Quaternion.cpp
+++ b/src/OpenSpaceToolkit/Mathematics/Geometry/3D/Transformation/Rotation/Quaternion.cpp
@@ -178,7 +178,7 @@ bool Quaternion::isUnitary(const Real& aNormTolerance) const
         throw ostk::core::error::runtime::Undefined("Norm tolerance");
     }
 
-    return std::abs(((x_ * x_) + (y_ * y_) + (z_ * z_) + (s_ * s_)) - 1.0) <= aNormTolerance;
+    return std::abs(this->norm() - 1.0) <= aNormTolerance;
 }
 
 bool Quaternion::isNear(const Quaternion& aQuaternion, const Angle& anAngularTolerance) const

--- a/test/OpenSpaceToolkit/Mathematics/Geometry/3D/Transformations/Rotations/Quaternion.test.cpp
+++ b/test/OpenSpaceToolkit/Mathematics/Geometry/3D/Transformations/Rotations/Quaternion.test.cpp
@@ -352,8 +352,8 @@ TEST(OpenSpaceToolkit_Mathematics_Geometry_3D_Transformation_Rotation_Quaternion
     }
 
     {
-        EXPECT_FALSE(Quaternion::XYZS(1.0001, 0.0, 0.0, 0.0).isUnitary(Real(0.0001)));
-        EXPECT_TRUE(Quaternion::XYZS(1.0001, 0.0, 0.0, 0.0).isUnitary(Real(0.0003)));
+        EXPECT_TRUE(Quaternion::XYZS(1.0001, 0.0, 0.0, 0.0).isUnitary(Real(0.0001)));
+        EXPECT_FALSE(Quaternion::XYZS(1.0001, 0.0, 0.0, 0.0).isUnitary(Real(0.00005)));
     }
 
     {


### PR DESCRIPTION
The unitary check wasn't square-rooting the sum-squared of the components, leading to false positives for near-(but not exactly)-unitary quaternions. The unit test was also wrong, and was actually confirming the false behaviour. 