### PR TITLE
fix: Interval::generateArrayWithStep should respect interval type

### DIFF
--- a/include/OpenSpaceToolkit/Mathematics/Object/Interval.hpp
+++ b/include/OpenSpaceToolkit/Mathematics/Object/Interval.hpp
@@ -228,7 +228,7 @@ class Interval : public IntervalBase
 
     Interval<T> getUnionWith(const Interval& anInterval) const;
 
-    /// @brief              Generate array from a given step
+    /// @brief              Generate array from a given step, respecting the openness of the interval.
     ///
     /// @code
     ///                     Interval<Real> interval = Interval<Real>::Closed(0.0, 1.0) ;
@@ -241,7 +241,7 @@ class Interval : public IntervalBase
     template <class U>
     ctnr::Array<T> generateArrayWithStep(const U& aStep) const;
 
-    /// @brief              Generate array with a given size
+    /// @brief              Generate array with a given size, respecting the openness of the interval.
     ///
     /// @code
     ///                     Interval<Real> interval = Interval<Real>::Closed(0.0, 1.0) ;

--- a/src/OpenSpaceToolkit/Mathematics/Object/Interval.tpp
+++ b/src/OpenSpaceToolkit/Mathematics/Object/Interval.tpp
@@ -397,14 +397,19 @@ ctnr::Array<T> Interval<T>::generateArrayWithStep(const U& aStep) const
     {
         T value = this->accessLowerBound();
 
-        while (value <= this->accessUpperBound())
+        if ((type_ == Interval<T>::Type::Open) || (type_ == Interval<T>::Type::HalfOpenLeft))
+        {
+            value += aStep;
+        }
+
+        while (value < this->accessUpperBound())
         {
             grid.add(value);
 
             value += aStep;
         }
 
-        if (grid.accessLast() < this->accessUpperBound())
+        if ((type_ == Interval<T>::Type::Closed) || (type_ == Interval<T>::Type::HalfOpenLeft))
         {
             grid.add(this->accessUpperBound());
         }
@@ -413,14 +418,19 @@ ctnr::Array<T> Interval<T>::generateArrayWithStep(const U& aStep) const
     {
         T value = this->accessUpperBound();
 
-        while (value >= this->accessLowerBound())
+        if ((type_ == Interval<T>::Type::Open) || (type_ == Interval<T>::Type::HalfOpenRight))
+        {
+            value += aStep;
+        }
+
+        while (value > this->accessLowerBound())
         {
             grid.add(value);
 
             value += aStep;
         }
 
-        if (grid.accessLast() > this->accessLowerBound())
+        if ((type_ == Interval<T>::Type::Closed) || (type_ == Interval<T>::Type::HalfOpenRight))
         {
             grid.add(this->accessLowerBound());
         }

--- a/test/OpenSpaceToolkit/Mathematics/Object/Interval.test.cpp
+++ b/test/OpenSpaceToolkit/Mathematics/Object/Interval.test.cpp
@@ -1776,6 +1776,22 @@ TEST(OpenSpaceToolkit_Mathematics_Object_Interval, GenerateArrayWithStep)
         EXPECT_TRUE(array.isNear(Array<Real>({1.0, 0.5, 0.0}), Real::Epsilon()));
     }
 
+    {
+        const Interval<Real> interval = {0.0, 1.0, Interval<Real>::Type::Closed};
+
+        const Array<Real> array = interval.generateArrayWithStep(Real(2.0));
+
+        EXPECT_TRUE(array.isNear(Array<Real>({0.0, 1.0}), Real::Epsilon()));
+    }
+
+    {
+        const Interval<Real> interval = {0.0, 1.0, Interval<Real>::Type::Closed};
+
+        const Array<Real> array = interval.generateArrayWithStep(Real(-2.0));
+
+        EXPECT_TRUE(array.isNear(Array<Real>({1.0, 0.0}), Real::Epsilon()));
+    }
+
     // Open
 
     {
@@ -1792,6 +1808,22 @@ TEST(OpenSpaceToolkit_Mathematics_Object_Interval, GenerateArrayWithStep)
         const Array<Real> array = interval.generateArrayWithStep(Real(-0.5));
 
         EXPECT_TRUE(array.isNear(Array<Real>({0.5}), Real::Epsilon()));
+    }
+
+    {
+        const Interval<Real> interval = {0.0, 1.0, Interval<Real>::Type::Open};
+
+        const Array<Real> array = interval.generateArrayWithStep(Real(2.0));
+
+        EXPECT_TRUE(array.isEmpty());
+    }
+
+    {
+        const Interval<Real> interval = {0.0, 1.0, Interval<Real>::Type::Open};
+
+        const Array<Real> array = interval.generateArrayWithStep(Real(-2.0));
+
+        EXPECT_TRUE(array.isEmpty());
     }
 
     // Half-Open Left
@@ -1812,6 +1844,22 @@ TEST(OpenSpaceToolkit_Mathematics_Object_Interval, GenerateArrayWithStep)
         EXPECT_TRUE(array.isNear(Array<Real>({1.0, 0.5}), Real::Epsilon()));
     }
 
+    {
+        const Interval<Real> interval = {0.0, 1.0, Interval<Real>::Type::HalfOpenLeft};
+
+        const Array<Real> array = interval.generateArrayWithStep(Real(2.0));
+
+        EXPECT_TRUE(array.isNear(Array<Real>({1.0}), Real::Epsilon()));
+    }
+
+    {
+        const Interval<Real> interval = {0.0, 1.0, Interval<Real>::Type::HalfOpenLeft};
+
+        const Array<Real> array = interval.generateArrayWithStep(Real(-2.0));
+
+        EXPECT_TRUE(array.isNear(Array<Real>({1.0}), Real::Epsilon()));
+    }
+
     // Half-Open Right
 
     {
@@ -1828,6 +1876,22 @@ TEST(OpenSpaceToolkit_Mathematics_Object_Interval, GenerateArrayWithStep)
         const Array<Real> array = interval.generateArrayWithStep(Real(-0.5));
 
         EXPECT_TRUE(array.isNear(Array<Real>({0.5, 0.0}), Real::Epsilon()));
+    }
+
+    {
+        const Interval<Real> interval = {0.0, 1.0, Interval<Real>::Type::HalfOpenRight};
+
+        const Array<Real> array = interval.generateArrayWithStep(Real(2.0));
+
+        EXPECT_TRUE(array.isNear(Array<Real>({0.0}), Real::Epsilon()));
+    }
+
+    {
+        const Interval<Real> interval = {0.0, 1.0, Interval<Real>::Type::HalfOpenRight};
+
+        const Array<Real> array = interval.generateArrayWithStep(Real(-2.0));
+
+        EXPECT_TRUE(array.isNear(Array<Real>({0.0}), Real::Epsilon()));
     }
 
     {

--- a/test/OpenSpaceToolkit/Mathematics/Object/Interval.test.cpp
+++ b/test/OpenSpaceToolkit/Mathematics/Object/Interval.test.cpp
@@ -1752,20 +1752,88 @@ TEST(OpenSpaceToolkit_Mathematics_Object_Interval, GetUnionWith)
     }
 }
 
-// TEST (OpenSpaceToolkit_Mathematics_Object_Interval, GenerateArrayWithStep)
-// {
+TEST(OpenSpaceToolkit_Mathematics_Object_Interval, GenerateArrayWithStep)
+{
+    using ostk::core::container::Array;
+    using ostk::core::type::Real;
+    using ostk::mathematics::object::Interval;
 
-//     using ostk::core::type::Real ;
+    // Closed
 
-//     using ostk::mathematics::object::Interval ;
+    {
+        const Interval<Real> interval = {0.0, 1.0, Interval<Real>::Type::Closed};
 
-//     {
+        const Array<Real> array = interval.generateArrayWithStep(Real(0.5));
 
-//         FAIL() ;
+        EXPECT_TRUE(array.isNear(Array<Real>({0.0, 0.5, 1.0}), Real::Epsilon()));
+    }
 
-//     }
+    {
+        const Interval<Real> interval = {0.0, 1.0, Interval<Real>::Type::Closed};
 
-// }
+        const Array<Real> array = interval.generateArrayWithStep(Real(-0.5));
+
+        EXPECT_TRUE(array.isNear(Array<Real>({1.0, 0.5, 0.0}), Real::Epsilon()));
+    }
+
+    // Open
+
+    {
+        const Interval<Real> interval = {0.0, 1.0, Interval<Real>::Type::Open};
+
+        const Array<Real> array = interval.generateArrayWithStep(Real(0.5));
+
+        EXPECT_TRUE(array.isNear(Array<Real>({0.5}), Real::Epsilon()));
+    }
+
+    {
+        const Interval<Real> interval = {0.0, 1.0, Interval<Real>::Type::Open};
+
+        const Array<Real> array = interval.generateArrayWithStep(Real(-0.5));
+
+        EXPECT_TRUE(array.isNear(Array<Real>({0.5}), Real::Epsilon()));
+    }
+
+    // Half-Open Left
+
+    {
+        const Interval<Real> interval = {0.0, 1.0, Interval<Real>::Type::HalfOpenLeft};
+
+        const Array<Real> array = interval.generateArrayWithStep(Real(0.5));
+
+        EXPECT_TRUE(array.isNear(Array<Real>({0.5, 1.0}), Real::Epsilon()));
+    }
+
+    {
+        const Interval<Real> interval = {0.0, 1.0, Interval<Real>::Type::HalfOpenLeft};
+
+        const Array<Real> array = interval.generateArrayWithStep(Real(-0.5));
+
+        EXPECT_TRUE(array.isNear(Array<Real>({1.0, 0.5}), Real::Epsilon()));
+    }
+
+    // Half-Open Right
+
+    {
+        const Interval<Real> interval = {0.0, 1.0, Interval<Real>::Type::HalfOpenRight};
+
+        const Array<Real> array = interval.generateArrayWithStep(Real(0.5));
+
+        EXPECT_TRUE(array.isNear(Array<Real>({0.0, 0.5}), Real::Epsilon()));
+    }
+
+    {
+        const Interval<Real> interval = {0.0, 1.0, Interval<Real>::Type::HalfOpenRight};
+
+        const Array<Real> array = interval.generateArrayWithStep(Real(-0.5));
+
+        EXPECT_TRUE(array.isNear(Array<Real>({0.5, 0.0}), Real::Epsilon()));
+    }
+
+    {
+        EXPECT_ANY_THROW(Interval<Real>(0.0, 1.0, Interval<Real>::Type::Closed).generateArrayWithStep(Real(0.0)));
+    }
+}
 
 TEST(OpenSpaceToolkit_Mathematics_Object_Interval, GenerateArrayWithSize)
 {


### PR DESCRIPTION
When generating an array from an interval with a given step size, the resultant `grid` should respect the openness of the Interval. Currently, it always includes the bounds of the Interval in the grid. This is already the case for `Interval::generateArrayWithSize`. Also re-enables the testcases for this function. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved array generation from intervals to accurately respect interval bounds and step direction, ensuring correct inclusion or exclusion of endpoints based on interval type.

* **Tests**
  * Added comprehensive tests for array generation across all interval types and step directions.
  * Included a test to verify that using a zero step correctly raises an exception.

* **Documentation**
  * Updated method descriptions to clarify that array generation respects interval openness.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->