### PR TITLE
feat: add quaternion interpolator

### DIFF
--- a/bindings/python/src/OpenSpaceToolkitMathematicsPy/CurveFitting.cpp
+++ b/bindings/python/src/OpenSpaceToolkitMathematicsPy/CurveFitting.cpp
@@ -2,6 +2,7 @@
 
 #include <OpenSpaceToolkitMathematicsPy/CurveFitting/Interpolator.cpp>
 #include <OpenSpaceToolkitMathematicsPy/CurveFitting/MatrixInterpolator.cpp>
+#include <OpenSpaceToolkitMathematicsPy/CurveFitting/QuaternionInterpolator.cpp>
 
 inline void OpenSpaceToolkitMathematicsPy_CurveFitting(pybind11::module& aModule)
 {
@@ -11,4 +12,5 @@ inline void OpenSpaceToolkitMathematicsPy_CurveFitting(pybind11::module& aModule
     // Add object to python "interpolators" submodules
     OpenSpaceToolkitMathematicsPy_CurveFitting_Interpolator(curve_fitting);
     OpenSpaceToolkitMathematicsPy_CurveFitting_MatrixInterpolator(curve_fitting);
+    OpenSpaceToolkitMathematicsPy_CurveFitting_QuaternionInterpolator(curve_fitting);
 }

--- a/bindings/python/src/OpenSpaceToolkitMathematicsPy/CurveFitting/QuaternionInterpolator.cpp
+++ b/bindings/python/src/OpenSpaceToolkitMathematicsPy/CurveFitting/QuaternionInterpolator.cpp
@@ -1,0 +1,12 @@
+/// Apache License 2.0
+
+#include <OpenSpaceToolkitMathematicsPy/CurveFitting/QuaternionInterpolator/SLERP.cpp>
+
+inline void OpenSpaceToolkitMathematicsPy_CurveFitting_QuaternionInterpolator(pybind11::module& aModule)
+{
+    // Create "quaternion_interpolator" python submodule
+    auto quaternion_interpolator = aModule.def_submodule("quaternion_interpolator");
+
+    // Add object to python "quaternion_interpolator" submodules
+    OpenSpaceToolkitMathematicsPy_CurveFitting_QuaternionInterpolator_SLERP(quaternion_interpolator);
+}

--- a/bindings/python/src/OpenSpaceToolkitMathematicsPy/CurveFitting/QuaternionInterpolator/SLERP.cpp
+++ b/bindings/python/src/OpenSpaceToolkitMathematicsPy/CurveFitting/QuaternionInterpolator/SLERP.cpp
@@ -1,0 +1,96 @@
+/// Apache License 2.0
+
+#include <OpenSpaceToolkit/Mathematics/CurveFitting/QuaternionInterpolator/SLERP.hpp>
+
+inline void OpenSpaceToolkitMathematicsPy_CurveFitting_QuaternionInterpolator_SLERP(pybind11::module& aModule)
+{
+    using namespace pybind11;
+
+    using ostk::core::container::Array;
+
+    using ostk::mathematics::geometry::d3::transformation::rotation::Quaternion;
+    using ostk::mathematics::object::VectorXd;
+
+    using ostk::mathematics::curvefitting::quaternioninterpolator::SLERP;
+
+    class_<SLERP>(aModule, "SLERP")
+
+        .def(
+            init<const VectorXd&, const Array<Quaternion>&>(),
+            R"doc(
+                Create a Spherical Linear Interpolation (SLERP) interpolator for quaternions.
+
+                Performs interpolation of unit quaternions (orientations) using Spherical Linear
+                Interpolation (SLERP). The interpolated quaternion is computed along the shortest
+                great-circle arc on the unit hypersphere, ensuring a constant angular velocity
+                between the two bracketing orientations.
+
+                The input quaternions are normalized at construction time.
+
+                Args:
+                    x (np.array): The x-coordinates of data points (must be strictly monotonically increasing).
+                    quaternions (list[Quaternion]): List of quaternions (all defined).
+
+                Example:
+                    >>> import numpy as np
+                    >>> x = np.array([0.0, 1.0])
+                    >>> interpolator = SLERP(x, [q0, q1])
+            )doc",
+            arg("x"),
+            arg("quaternions")
+        )
+
+        .def(
+            "evaluate",
+            overload_cast<const double&>(&SLERP::evaluate, const_),
+            R"doc(
+                Evaluate the interpolation at a single point.
+
+                Returns the interpolated (normalized) quaternion at the given x value.
+                Values outside the x range are clamped to the nearest endpoint quaternion.
+
+                Args:
+                    x (float): The x-coordinate to evaluate at.
+
+                Returns:
+                    Quaternion: The interpolated quaternion.
+
+                Example:
+                    >>> result = interpolator.evaluate(0.5)
+            )doc",
+            arg("x")
+        )
+        .def(
+            "evaluate",
+            overload_cast<const VectorXd&>(&SLERP::evaluate, const_),
+            R"doc(
+                Evaluate the interpolation at multiple points.
+
+                Args:
+                    x (np.array): The x-coordinates to evaluate at.
+
+                Returns:
+                    list[Quaternion]: List of interpolated quaternions.
+
+                Example:
+                    >>> results = interpolator.evaluate(np.array([0.0, 0.5, 1.0]))
+            )doc",
+            arg("x")
+        )
+
+        .def(
+            "get_quaternions",
+            &SLERP::getQuaternions,
+            R"doc(
+                Get the (normalized) quaternions used by the interpolator.
+
+                Returns:
+                    list[Quaternion]: The list of quaternions.
+
+                Example:
+                    >>> quaternions = interpolator.get_quaternions()
+            )doc"
+        )
+
+        ;
+}

--- a/bindings/python/test/curve_fitting/quaternion_interpolator/test_slerp.py
+++ b/bindings/python/test/curve_fitting/quaternion_interpolator/test_slerp.py
@@ -1,0 +1,129 @@
+# Apache License 2.0
+
+import numpy as np
+import pytest
+
+from ostk.mathematics.geometry import Angle
+from ostk.mathematics.geometry.d3.transformation.rotation import Quaternion
+from ostk.mathematics.geometry.d3.transformation.rotation import RotationVector
+
+from ostk.mathematics.curve_fitting.quaternion_interpolator import SLERP
+
+
+def z_rotation(angle_in_degrees: float) -> Quaternion:
+    return Quaternion.rotation_vector(
+        RotationVector(np.array((0.0, 0.0, 1.0)), Angle.degrees(angle_in_degrees))
+    )
+
+
+@pytest.fixture
+def q0() -> Quaternion:
+    return z_rotation(0.0)
+
+
+@pytest.fixture
+def q1() -> Quaternion:
+    return z_rotation(90.0)
+
+
+@pytest.fixture
+def interpolator(
+    q0: Quaternion,
+    q1: Quaternion,
+) -> SLERP:
+    return SLERP(
+        x=np.array([0.0, 1.0]),
+        quaternions=[q0, q1],
+    )
+
+
+class TestSLERP:
+    def test_constructor_success(
+        self,
+        interpolator: SLERP,
+    ):
+        assert interpolator is not None
+        assert isinstance(interpolator, SLERP)
+
+    def test_constructor_mismatched_sizes(
+        self,
+        q0: Quaternion,
+        q1: Quaternion,
+    ):
+        with pytest.raises(RuntimeError):
+            SLERP(
+                x=np.array([0.0, 1.0, 2.0]),
+                quaternions=[q0, q1],
+            )
+
+    def test_constructor_too_few_points(
+        self,
+        q0: Quaternion,
+    ):
+        with pytest.raises(RuntimeError):
+            SLERP(
+                x=np.array([0.0]),
+                quaternions=[q0],
+            )
+
+    def test_constructor_non_monotonic_x(
+        self,
+        q0: Quaternion,
+        q1: Quaternion,
+    ):
+        with pytest.raises(RuntimeError):
+            SLERP(
+                x=np.array([0.0, 2.0, 1.0]),
+                quaternions=[q0, z_rotation(45.0), q1],
+            )
+
+    def test_constructor_duplicate_x(
+        self,
+        q0: Quaternion,
+        q1: Quaternion,
+    ):
+        with pytest.raises(RuntimeError):
+            SLERP(
+                x=np.array([0.0, 1.0, 1.0]),
+                quaternions=[q0, z_rotation(45.0), q1],
+            )
+
+    def test_evaluate_single(
+        self,
+        interpolator: SLERP,
+    ):
+        result = interpolator.evaluate(0.5)
+
+        assert result is not None
+        assert isinstance(result, Quaternion)
+        assert result.is_defined()
+
+    def test_evaluate_endpoints(
+        self,
+        interpolator: SLERP,
+        q0: Quaternion,
+        q1: Quaternion,
+    ):
+        assert interpolator.evaluate(0.0).is_near(q0, Angle.degrees(1e-9))
+        assert interpolator.evaluate(1.0).is_near(q1, Angle.degrees(1e-9))
+
+    def test_evaluate_vector(
+        self,
+        interpolator: SLERP,
+    ):
+        results = interpolator.evaluate(np.array([0.0, 0.5, 1.0]))
+
+        assert len(results) == 3
+        for result in results:
+            assert isinstance(result, Quaternion)
+            assert result.is_defined()
+
+    def test_get_quaternions(
+        self,
+        interpolator: SLERP,
+    ):
+        quaternions = interpolator.get_quaternions()
+
+        assert len(quaternions) == 2
+        for quaternion in quaternions:
+            assert isinstance(quaternion, Quaternion)

--- a/include/OpenSpaceToolkit/Mathematics/CurveFitting/QuaternionInterpolator/SLERP.hpp
+++ b/include/OpenSpaceToolkit/Mathematics/CurveFitting/QuaternionInterpolator/SLERP.hpp
@@ -1,0 +1,114 @@
+/// Apache License 2.0
+#ifndef __OpenSpaceToolkit_Mathematics_QuaternionInterpolator_SLERP__
+#define __OpenSpaceToolkit_Mathematics_QuaternionInterpolator_SLERP__
+
+#include <OpenSpaceToolkit/Core/Container/Array.hpp>
+#include <OpenSpaceToolkit/Core/Container/Pair.hpp>
+#include <OpenSpaceToolkit/Core/Type/Index.hpp>
+#include <OpenSpaceToolkit/Core/Type/Real.hpp>
+#include <OpenSpaceToolkit/Core/Type/Size.hpp>
+
+#include <OpenSpaceToolkit/Mathematics/Geometry/3D/Transformation/Rotation/Quaternion.hpp>
+#include <OpenSpaceToolkit/Mathematics/Object/Vector.hpp>
+
+namespace ostk
+{
+namespace mathematics
+{
+namespace curvefitting
+{
+namespace quaternioninterpolator
+{
+
+using ostk::core::container::Array;
+using ostk::core::container::Pair;
+using ostk::core::type::Index;
+using ostk::core::type::Real;
+using ostk::core::type::Size;
+
+using ostk::mathematics::geometry::d3::transformation::rotation::Quaternion;
+using ostk::mathematics::object::VectorXd;
+
+/// @brief Spherical Linear Interpolation (SLERP) interpolator for quaternions
+///
+/// Performs interpolation of unit quaternions (orientations) using Spherical Linear
+/// Interpolation (SLERP). Given a query value, the two bracketing data points are located
+/// and the interpolated quaternion is computed along the shortest great-circle arc on the
+/// unit hypersphere, ensuring a constant angular velocity between the two orientations.
+///
+/// The input quaternions are normalized at construction time. Query values outside the
+/// x range are clamped to the nearest endpoint quaternion (no extrapolation).
+///
+/// @code{.cpp}
+///     VectorXd x(2);
+///     x << 0.0, 1.0;
+///     Array<Quaternion> quaternions = {q0, q1};
+///     SLERP interpolator(x, quaternions);
+///     Quaternion result = interpolator.evaluate(0.5);
+/// @endcode
+///
+/// @ref https://en.wikipedia.org/wiki/Slerp
+class SLERP
+{
+   public:
+    /// @brief Constructor
+    ///
+    /// Constructs a SLERP interpolator from x-coordinates and corresponding quaternions.
+    /// The quaternions are normalized at construction time.
+    ///
+    /// @code{.cpp}
+    ///     SLERP interpolator(x, quaternions);
+    /// @endcode
+    ///
+    /// @param anXVector A vector of x values (strictly monotonically increasing)
+    /// @param aQuaternionArray An array of (defined) quaternions
+    SLERP(const VectorXd& anXVector, const Array<Quaternion>& aQuaternionArray);
+
+    /// @brief Destructor
+    ~SLERP();
+
+    /// @brief Evaluate the interpolator at a single point
+    ///
+    /// Returns the interpolated (normalized) quaternion at the given x value. Values outside
+    /// the x range are clamped to the nearest endpoint quaternion.
+    ///
+    /// @code{.cpp}
+    ///     Quaternion result = interpolator.evaluate(0.5);
+    /// @endcode
+    ///
+    /// @param aQueryValue An x value
+    /// @return Interpolated quaternion
+    Quaternion evaluate(const double& aQueryValue) const;
+
+    /// @brief Evaluate the interpolator at multiple points
+    ///
+    /// @code{.cpp}
+    ///     Array<Quaternion> results = interpolator.evaluate(queryVector);
+    /// @endcode
+    ///
+    /// @param aQueryVector A vector of x values
+    /// @return Array of interpolated quaternions
+    Array<Quaternion> evaluate(const VectorXd& aQueryVector) const;
+
+    /// @brief Get the (normalized) quaternions used by the interpolator
+    ///
+    /// @code{.cpp}
+    ///     Array<Quaternion> quaternions = interpolator.getQuaternions();
+    /// @endcode
+    ///
+    /// @return The array of quaternions
+    Array<Quaternion> getQuaternions() const;
+
+   private:
+    VectorXd x_;
+    Array<Quaternion> quaternions_;
+
+    Pair<Index, Index> findIndexRange(const double& aQueryValue) const;
+};
+
+}  // namespace quaternioninterpolator
+}  // namespace curvefitting
+}  // namespace mathematics
+}  // namespace ostk
+
+#endif

--- a/src/OpenSpaceToolkit/Mathematics/CurveFitting/QuaternionInterpolator/SLERP.cpp
+++ b/src/OpenSpaceToolkit/Mathematics/CurveFitting/QuaternionInterpolator/SLERP.cpp
@@ -1,0 +1,106 @@
+/// Apache License 2.0
+
+#include <OpenSpaceToolkit/Core/Error.hpp>
+
+#include <OpenSpaceToolkit/Mathematics/CurveFitting/QuaternionInterpolator/SLERP.hpp>
+
+namespace ostk
+{
+namespace mathematics
+{
+namespace curvefitting
+{
+namespace quaternioninterpolator
+{
+
+SLERP::SLERP(const VectorXd& anXVector, const Array<Quaternion>& aQuaternionArray)
+    : x_(anXVector),
+      quaternions_()
+{
+    if (anXVector.size() < 2)
+    {
+        throw ostk::core::error::runtime::Wrong("x", "Insufficient data points.");
+    }
+
+    if (Size(anXVector.size()) != aQuaternionArray.getSize())
+    {
+        throw ostk::core::error::runtime::Wrong("x and quaternions", "Sizes are not consistent.");
+    }
+
+    // Check x is strictly monotonically increasing
+    for (int i = 1; i < anXVector.size(); ++i)
+    {
+        if (anXVector(i) <= anXVector(i - 1))
+        {
+            throw ostk::core::error::runtime::Wrong("x", "Must be strictly monotonically increasing.");
+        }
+    }
+
+    // Normalize quaternions
+    quaternions_.reserve(aQuaternionArray.getSize());
+    for (Size i = 0; i < aQuaternionArray.getSize(); ++i)
+    {
+        if (!aQuaternionArray[i].isDefined())
+        {
+            throw ostk::core::error::runtime::Undefined("Quaternion");
+        }
+
+        quaternions_.add(aQuaternionArray[i].toNormalized());
+    }
+}
+
+SLERP::~SLERP() {}
+
+Quaternion SLERP::evaluate(const double& aQueryValue) const
+{
+    const auto [previousIndex, nextIndex] = findIndexRange(aQueryValue);
+
+    if (previousIndex == nextIndex)
+    {
+        return quaternions_[previousIndex];
+    }
+
+    const Real ratio = (aQueryValue - x_(previousIndex)) / (x_(nextIndex) - x_(previousIndex));
+
+    return Quaternion::SLERP(quaternions_[previousIndex], quaternions_[nextIndex], ratio);
+}
+
+Array<Quaternion> SLERP::evaluate(const VectorXd& aQueryVector) const
+{
+    Array<Quaternion> results;
+    results.reserve(aQueryVector.size());
+
+    for (int i = 0; i < aQueryVector.size(); ++i)
+    {
+        results.add(evaluate(aQueryVector(i)));
+    }
+
+    return results;
+}
+
+Array<Quaternion> SLERP::getQuaternions() const
+{
+    return quaternions_;
+}
+
+Pair<Index, Index> SLERP::findIndexRange(const double& aQueryValue) const
+{
+    const Index index = std::distance(x_.begin(), std::lower_bound(x_.begin(), x_.end(), aQueryValue));
+
+    if (index == 0)
+    {
+        return {0, 0};
+    }
+
+    if (index == Index(x_.size()))
+    {
+        return {index - 1, index - 1};
+    }
+
+    return {index - 1, index};
+}
+
+}  // namespace quaternioninterpolator
+}  // namespace curvefitting
+}  // namespace mathematics
+}  // namespace ostk

--- a/test/OpenSpaceToolkit/Mathematics/CurveFitting/QuaternionInterpolator/SLERP.test.cpp
+++ b/test/OpenSpaceToolkit/Mathematics/CurveFitting/QuaternionInterpolator/SLERP.test.cpp
@@ -1,0 +1,229 @@
+/// Apache License 2.0
+
+#include <OpenSpaceToolkit/Core/Container/Array.hpp>
+#include <OpenSpaceToolkit/Core/Error.hpp>
+#include <OpenSpaceToolkit/Core/Type/Real.hpp>
+#include <OpenSpaceToolkit/Core/Type/Size.hpp>
+
+#include <OpenSpaceToolkit/Mathematics/CurveFitting/QuaternionInterpolator/SLERP.hpp>
+#include <OpenSpaceToolkit/Mathematics/Geometry/Angle.hpp>
+#include <OpenSpaceToolkit/Mathematics/Geometry/3D/Transformation/Rotation/Quaternion.hpp>
+#include <OpenSpaceToolkit/Mathematics/Geometry/3D/Transformation/Rotation/RotationVector.hpp>
+#include <OpenSpaceToolkit/Mathematics/Object/Vector.hpp>
+
+#include <Global.test.hpp>
+
+using ostk::core::container::Array;
+using ostk::core::type::Real;
+using ostk::core::type::Size;
+
+using ostk::mathematics::curvefitting::quaternioninterpolator::SLERP;
+using ostk::mathematics::geometry::Angle;
+using ostk::mathematics::geometry::d3::transformation::rotation::Quaternion;
+using ostk::mathematics::geometry::d3::transformation::rotation::RotationVector;
+using ostk::mathematics::object::Vector3d;
+using ostk::mathematics::object::VectorXd;
+
+class OpenSpaceToolkit_Mathematics_QuaternionInterpolator_SLERP : public ::testing::Test
+{
+   protected:
+    // Rotation about the +Z axis by a given angle (degrees)
+    Quaternion makeZRotation(const double& anAngleInDegrees) const
+    {
+        return Quaternion::RotationVector(RotationVector({0.0, 0.0, 1.0}, Angle::Degrees(anAngleInDegrees)));
+    }
+
+    const Angle tolerance_ = Angle::Degrees(1e-9);
+};
+
+TEST_F(OpenSpaceToolkit_Mathematics_QuaternionInterpolator_SLERP, Constructor)
+{
+    // Success
+    {
+        VectorXd x(2);
+        x << 0.0, 1.0;
+
+        Array<Quaternion> quaternions = {makeZRotation(0.0), makeZRotation(90.0)};
+
+        EXPECT_NO_THROW(SLERP(x, quaternions));
+    }
+
+    // Too few points
+    {
+        VectorXd x(1);
+        x << 0.0;
+
+        Array<Quaternion> quaternions = {Quaternion::Unit()};
+
+        EXPECT_THROW(SLERP(x, quaternions), ostk::core::error::runtime::Wrong);
+    }
+
+    // Mismatched sizes
+    {
+        VectorXd x(3);
+        x << 0.0, 1.0, 2.0;
+
+        Array<Quaternion> quaternions = {makeZRotation(0.0), makeZRotation(90.0)};
+
+        EXPECT_THROW(SLERP(x, quaternions), ostk::core::error::runtime::Wrong);
+    }
+
+    // Non-monotonic x (decreasing)
+    {
+        VectorXd x(3);
+        x << 0.0, 2.0, 1.0;
+
+        Array<Quaternion> quaternions = {makeZRotation(0.0), makeZRotation(45.0), makeZRotation(90.0)};
+
+        EXPECT_THROW(SLERP(x, quaternions), ostk::core::error::runtime::Wrong);
+    }
+
+    // Non-monotonic x (duplicate values)
+    {
+        VectorXd x(3);
+        x << 0.0, 1.0, 1.0;
+
+        Array<Quaternion> quaternions = {makeZRotation(0.0), makeZRotation(45.0), makeZRotation(90.0)};
+
+        EXPECT_THROW(SLERP(x, quaternions), ostk::core::error::runtime::Wrong);
+    }
+
+    // Undefined quaternion
+    {
+        VectorXd x(2);
+        x << 0.0, 1.0;
+
+        Array<Quaternion> quaternions = {Quaternion::Unit(), Quaternion::Undefined()};
+
+        EXPECT_THROW(SLERP(x, quaternions), ostk::core::error::runtime::Undefined);
+    }
+}
+
+TEST_F(OpenSpaceToolkit_Mathematics_QuaternionInterpolator_SLERP, Evaluate_Endpoints)
+{
+    const Quaternion q0 = makeZRotation(0.0);
+    const Quaternion q1 = makeZRotation(90.0);
+
+    VectorXd x(2);
+    x << 0.0, 1.0;
+
+    Array<Quaternion> quaternions = {q0, q1};
+    SLERP interpolator(x, quaternions);
+
+    EXPECT_TRUE(interpolator.evaluate(0.0).isNear(q0, tolerance_));
+    EXPECT_TRUE(interpolator.evaluate(1.0).isNear(q1, tolerance_));
+}
+
+TEST_F(OpenSpaceToolkit_Mathematics_QuaternionInterpolator_SLERP, Evaluate_Midpoint)
+{
+    // SLERP halfway between a 0 deg and a 90 deg rotation about the same axis is a 45 deg rotation
+    const Quaternion q0 = makeZRotation(0.0);
+    const Quaternion q1 = makeZRotation(90.0);
+
+    VectorXd x(2);
+    x << 0.0, 1.0;
+
+    Array<Quaternion> quaternions = {q0, q1};
+    SLERP interpolator(x, quaternions);
+
+    const Quaternion result = interpolator.evaluate(0.5);
+
+    EXPECT_TRUE(result.isNear(makeZRotation(45.0), tolerance_));
+}
+
+TEST_F(OpenSpaceToolkit_Mathematics_QuaternionInterpolator_SLERP, Evaluate_ConstantAngularVelocity)
+{
+    // SLERP traverses the great-circle arc at constant angular velocity:
+    // the interpolated rotation angle should grow linearly with the query value
+    const Quaternion q0 = makeZRotation(0.0);
+    const Quaternion q1 = makeZRotation(90.0);
+
+    VectorXd x(2);
+    x << 0.0, 1.0;
+
+    Array<Quaternion> quaternions = {q0, q1};
+    SLERP interpolator(x, quaternions);
+
+    for (double ratio = 0.0; ratio <= 1.0; ratio += 0.1)
+    {
+        const Quaternion result = interpolator.evaluate(ratio);
+
+        EXPECT_TRUE(result.isNear(makeZRotation(90.0 * ratio), tolerance_)) << "Mismatch at ratio=" << ratio;
+
+        // Result must be a unit quaternion
+        EXPECT_NEAR(result.toVector().norm(), 1.0, 1e-12);
+    }
+}
+
+TEST_F(OpenSpaceToolkit_Mathematics_QuaternionInterpolator_SLERP, Evaluate_MultipleSegments)
+{
+    VectorXd x(3);
+    x << 0.0, 1.0, 2.0;
+
+    Array<Quaternion> quaternions = {makeZRotation(0.0), makeZRotation(40.0), makeZRotation(120.0)};
+    SLERP interpolator(x, quaternions);
+
+    // Within first segment
+    EXPECT_TRUE(interpolator.evaluate(0.5).isNear(makeZRotation(20.0), tolerance_));
+
+    // Within second segment
+    EXPECT_TRUE(interpolator.evaluate(1.5).isNear(makeZRotation(80.0), tolerance_));
+}
+
+TEST_F(OpenSpaceToolkit_Mathematics_QuaternionInterpolator_SLERP, Evaluate_Vector)
+{
+    const Quaternion q0 = makeZRotation(0.0);
+    const Quaternion q1 = makeZRotation(90.0);
+
+    VectorXd x(2);
+    x << 0.0, 1.0;
+
+    Array<Quaternion> quaternions = {q0, q1};
+    SLERP interpolator(x, quaternions);
+
+    VectorXd query(3);
+    query << 0.0, 0.5, 1.0;
+
+    const Array<Quaternion> results = interpolator.evaluate(query);
+
+    EXPECT_EQ(results.getSize(), Size(3));
+    EXPECT_TRUE(results[0].isNear(q0, tolerance_));
+    EXPECT_TRUE(results[1].isNear(makeZRotation(45.0), tolerance_));
+    EXPECT_TRUE(results[2].isNear(q1, tolerance_));
+}
+
+TEST_F(OpenSpaceToolkit_Mathematics_QuaternionInterpolator_SLERP, Evaluate_Extrapolation)
+{
+    const Quaternion q0 = makeZRotation(0.0);
+    const Quaternion q1 = makeZRotation(90.0);
+
+    VectorXd x(2);
+    x << 0.0, 1.0;
+
+    Array<Quaternion> quaternions = {q0, q1};
+    SLERP interpolator(x, quaternions);
+
+    // Before range: clamp to first
+    EXPECT_TRUE(interpolator.evaluate(-1.0).isNear(q0, tolerance_));
+
+    // After range: clamp to last
+    EXPECT_TRUE(interpolator.evaluate(2.0).isNear(q1, tolerance_));
+}
+
+TEST_F(OpenSpaceToolkit_Mathematics_QuaternionInterpolator_SLERP, GetQuaternions)
+{
+    const Quaternion q0 = makeZRotation(0.0);
+    const Quaternion q1 = makeZRotation(90.0);
+
+    VectorXd x(2);
+    x << 0.0, 1.0;
+
+    Array<Quaternion> quaternions = {q0, q1};
+    SLERP interpolator(x, quaternions);
+
+    const Array<Quaternion> result = interpolator.getQuaternions();
+
+    EXPECT_EQ(result.getSize(), Size(2));
+    EXPECT_TRUE(result[0].isNear(q0, tolerance_));
+    EXPECT_TRUE(result[1].isNear(q1, tolerance_));
+}

--- a/test/OpenSpaceToolkit/Mathematics/CurveFitting/QuaternionInterpolator/SLERP.test.cpp
+++ b/test/OpenSpaceToolkit/Mathematics/CurveFitting/QuaternionInterpolator/SLERP.test.cpp
@@ -6,9 +6,9 @@
 #include <OpenSpaceToolkit/Core/Type/Size.hpp>
 
 #include <OpenSpaceToolkit/Mathematics/CurveFitting/QuaternionInterpolator/SLERP.hpp>
-#include <OpenSpaceToolkit/Mathematics/Geometry/Angle.hpp>
 #include <OpenSpaceToolkit/Mathematics/Geometry/3D/Transformation/Rotation/Quaternion.hpp>
 #include <OpenSpaceToolkit/Mathematics/Geometry/3D/Transformation/Rotation/RotationVector.hpp>
+#include <OpenSpaceToolkit/Mathematics/Geometry/Angle.hpp>
 #include <OpenSpaceToolkit/Mathematics/Object/Vector.hpp>
 
 #include <Global.test.hpp>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added spherical linear interpolation (SLERP) for quaternions in Python, enabling smooth rotation interpolation.
  * Supports both single-point and vectorized evaluation of quaternion interpolation.

* **Tests**
  * Added comprehensive test coverage for SLERP quaternion interpolation functionality, including edge cases and validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->