### PR TITLE
build: support Python 3.14

### DIFF
--- a/bindings/python/CMakeLists.txt
+++ b/bindings/python/CMakeLists.txt
@@ -196,7 +196,7 @@ FIND_PACKAGE (pybind11 2.12.0 REQUIRED)
 ### Python
 
 # Python versions to build for and support
-SET (PYTHON_SEARCH_VERSIONS 3.9 3.10 3.11 3.12 3.13 CACHE STRING "Versions of Python bindings to build.")
+SET (PYTHON_SEARCH_VERSIONS 3.9 3.10 3.11 3.12 3.13 3.14 CACHE STRING "Versions of Python bindings to build.")
 
 MESSAGE (STATUS "Looking for available python versions...")
 FOREACH (PYTHON_VERSION ${PYTHON_SEARCH_VERSIONS})
@@ -205,7 +205,7 @@ FOREACH (PYTHON_VERSION ${PYTHON_SEARCH_VERSIONS})
         MESSAGE (STATUS "Python ${PYTHON_VERSION} found.")
         LIST (APPEND PYTHON_VERSIONS ${PYTHON_VERSION})
     ELSE ()
-        MESSAGE (STATUS "Python ${PYTHON_VERSION} not found.")
+        MESSAGE (FATAL_ERROR "Python ${PYTHON_VERSION} was requested but not found.")
     ENDIF ()
 ENDFOREACH ()
 


### PR DESCRIPTION
Needs https://github.com/open-space-collective/open-space-toolkit/pull/187

Also throws a fatal error if a requested Python version is NOT found, rather than just not building it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Build Improvements**
  * Added support for detecting and building with Python 3.14.
  * Builds now stop with a clear error when the requested Python version is unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->